### PR TITLE
Refetch data after successful project addition

### DIFF
--- a/apps/web/src/components/admin/dataset-editor/dataset-projects.tsx
+++ b/apps/web/src/components/admin/dataset-editor/dataset-projects.tsx
@@ -25,7 +25,7 @@ export function DatasetProjects({ datasetId, organizationId }: DatasetProjectsPr
   const [isAddingToProject, setIsAddingToProject] = useState(false);
   const t = useTranslations("adminDatasetEditor");
 
-  const { data, isSuccess, isError } = useQueryApi<ApiResponsePayload<ResponseRow>>(
+  const { data, isSuccess, isError, refetch } = useQueryApi<ApiResponsePayload<ResponseRow>>(
     `/api/datasets/${datasetId}/projects`,
     {
       limit: 100,
@@ -42,6 +42,7 @@ export function DatasetProjects({ datasetId, organizationId }: DatasetProjectsPr
     setIsAddingToProject(true);
     try {
       await addToProject(datasetId, selectedProject);
+      refetch();
       toast.success(t("addToProjectSuccess"));
     } catch (error) {
       console.error(t("addToProjectError"), error);


### PR DESCRIPTION
- Added `refetch` to the destructuring assignment from `useQueryApi`.
- Updated `DatasetProjects` function to call `refetch` after a successful project addition.
- This ensures that the dataset projects list is refreshed with the latest data.