### PR TITLE
Add bar skeleton and spinner components

### DIFF
--- a/apps/web/src/components/chart/bar-skeleton.tsx
+++ b/apps/web/src/components/chart/bar-skeleton.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { Skeleton } from "@/components/ui/skeleton";
+
+const BarSkeleton = () => {
+  return (
+    <div className="w-full max-w-2xl rounded-lg p-4">
+      {/* Title */}
+      <Skeleton className="mb-4 h-6 w-48" />
+
+      {/* Chart Area */}
+      <div className="flex h-64 items-end justify-around gap-2 rounded p-4">
+        <Skeleton className="h-20 w-8" />
+        <Skeleton className="h-32 w-8" />
+        <Skeleton className="h-16 w-8" />
+        <Skeleton className="h-28 w-8" />
+        <Skeleton className="h-24 w-8" />
+        <Skeleton className="h-36 w-8" />
+      </div>
+    </div>
+  );
+};
+
+export default BarSkeleton;

--- a/apps/web/src/components/project/adhoc-analysis.tsx
+++ b/apps/web/src/components/project/adhoc-analysis.tsx
@@ -9,6 +9,7 @@ import { DatasetVariable } from "@/types/dataset-variable";
 import { type Project } from "@/types/project";
 import { AnalysisChartType, StatsRequest } from "@/types/stats";
 import { BarAdhoc } from "../chart/bar-adhoc";
+import BarSkeleton from "../chart/bar-skeleton";
 import { HorizontalBarAdhoc } from "../chart/horizontal-bar-adhoc";
 import { MetricsCards } from "../chart/metrics-cards";
 import { PieAdhoc } from "../chart/pie-adhoc";
@@ -52,7 +53,7 @@ export function AdHocAnalysis({ project }: AdHocAnalysisProps) {
 
   const t = useTranslations("projectAdhocAnalysis");
 
-  const { data, mutate } = useDatasetStats(selectedDataset || "", {
+  const { data, mutate, isPending } = useDatasetStats(selectedDataset || "", {
     onError: (error) => {
       console.error(t("errors.fetchStats"), error);
     },
@@ -71,6 +72,7 @@ export function AdHocAnalysis({ project }: AdHocAnalysisProps) {
   const handleAddVariable = (variable: DatasetVariable) => {
     setSelectedVariable(variable);
   };
+
   return (
     <div className="theme-container flex gap-4">
       <div className="flex w-64 max-w-64 min-w-64 flex-col gap-4">
@@ -83,6 +85,7 @@ export function AdHocAnalysis({ project }: AdHocAnalysisProps) {
         />
         {selectedDataset && <AdHocVariables datasetId={selectedDataset} onAddVariable={handleAddVariable} />}
       </div>
+      {isPending && <BarSkeleton />}
       {selectedDataset && selectedVariable && data && (
         <Tabs defaultValue="chart" className="w-full">
           <TabsList>

--- a/apps/web/src/components/ui/spinner.tsx
+++ b/apps/web/src/components/ui/spinner.tsx
@@ -1,0 +1,43 @@
+import { VariantProps, cva } from "class-variance-authority";
+import { Loader2 } from "lucide-react";
+import React from "react";
+import { cn } from "@/lib/utils";
+
+const spinnerVariants = cva("flex-col items-center justify-center", {
+  variants: {
+    show: {
+      true: "flex",
+      false: "hidden",
+    },
+  },
+  defaultVariants: {
+    show: true,
+  },
+});
+
+const loaderVariants = cva("animate-spin text-primary", {
+  variants: {
+    size: {
+      small: "size-6",
+      medium: "size-8",
+      large: "size-12",
+    },
+  },
+  defaultVariants: {
+    size: "medium",
+  },
+});
+
+interface SpinnerContentProps extends VariantProps<typeof spinnerVariants>, VariantProps<typeof loaderVariants> {
+  className?: string;
+  children?: React.ReactNode;
+}
+
+export function Spinner({ size, show, children, className }: SpinnerContentProps) {
+  return (
+    <span className={spinnerVariants({ show })}>
+      <Loader2 className={cn(loaderVariants({ size }), className)} />
+      {children}
+    </span>
+  );
+}


### PR DESCRIPTION
Created `BarSkeleton` component to display a loading state for bar charts. Updated `AdhocAnalysis` component to include the `BarSkeleton` component when data is pending. Added `Spinner` component from `class-variance-authority` to replace the custom spinner logic.