### PR TITLE
Add CLI service in docker-compose and GitHub Actions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -34,6 +34,10 @@ jobs:
             suffix: analysis
             dockerfile: ./apps/analysis/Dockerfile
             context: ./apps/analysis
+          - app: cli
+            suffix: cli
+            dockerfile: ./packages/cli/Dockerfile
+            context: .
           - app: db
             suffix: db
             dockerfile: ./packages/database/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,16 @@ services:
       - DOCKER_RUN_MIGRATIONS=1
       - DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-postgres}
 
+  cli:
+    build:
+      context: .
+      dockerfile: ./apps/cli/Dockerfile
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      - DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-postgres}
+
   analysis:
     build:
       context: ./apps/analysis

--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:22-alpine AS base
+
+WORKDIR /app
+
+FROM base AS builder-base
+
+ENV TURBO_TELEMETRY_DISABLED=1
+
+FROM builder-base AS builder
+
+RUN npm install --global turbo@^2
+
+COPY . .
+
+RUN turbo prune @repo/cli --docker
+
+FROM base AS runner
+
+COPY --from=builder /app/out/full/ .
+COPY --from=builder /app/packages/database/docker/entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/bin/sh"]

--- a/packages/cli/docker/entrypoint.sh
+++ b/packages/cli/docker/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+# Write DATABASE_URL to .env file if present
+if [ -n "${DATABASE_URL:-}" ]; then
+    echo "Writing DATABASE_URL to /app/packages/cli/.env"
+    mkdir -p /app/packages/cli
+    echo "DATABASE_URL=${DATABASE_URL}" > /app/packages/cli/.env
+fi
+


### PR DESCRIPTION
- Updated .github/workflows/docker-publish.yml to include the new cli app.
- Created a new Dockerfile for the CLI application under packages/cli/Dockerfile.
- Added an entrypoint.sh script for the CLI service to manage environment variables.