### PR TITLE
Refactor environment variable usage for sign-up and login functionality

### DIFF
--- a/apps/web/src/app/(auth)/auth/login/page.tsx
+++ b/apps/web/src/app/(auth)/auth/login/page.tsx
@@ -1,10 +1,10 @@
-import { auth } from "@/lib/auth";
+import { env } from "@/env";
 import { LoginForm } from "./form";
 
 export const dynamic = "force-dynamic";
 
 export default function Page() {
-  const signUpDisabled = auth.options.emailAndPassword.disableSignUp;
+  const signUpDisabled = !!env.AUTH_DISABLE_SIGNUP;
   return (
     <main className="flex min-h-screen flex-col items-center justify-center" data-testid="auth.login.page">
       <div className="w-md">

--- a/apps/web/src/app/(auth)/auth/sign-up/page.tsx
+++ b/apps/web/src/app/(auth)/auth/sign-up/page.tsx
@@ -1,11 +1,11 @@
 import { notFound } from "next/navigation";
-import { auth } from "@/lib/auth";
+import { env } from "@/env";
 import { SignUpForm } from "./form";
 
 export const dynamic = "force-dynamic";
 
 export default function Page() {
-  const signUpDisabled = auth.options.emailAndPassword.disableSignUp;
+  const signUpDisabled = !!env.AUTH_DISABLE_SIGNUP;
 
   if (signUpDisabled) {
     return notFound();

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -131,7 +131,7 @@ export const auth = betterAuth({
   emailAndPassword: {
     enabled: true,
     requireEmailVerification: true,
-    disableSignUp: env.AUTH_DISABLE_SIGNUP,
+    disableSignUp: false, // this needs to stay false, when private signup via invitation should work
     sendResetPassword: async (data: { user: { email: string; locale?: string }; url: string }) => {
       const { user, url } = data;
       const { heading, content, action } = getEmailMessage("passwordReset", user.locale);


### PR DESCRIPTION
Updated `login/page.tsx` and `sign-up/page.tsx` to use the `AUTH_DISABLE_SIGNUP` environment variable instead of `auth.options.emailAndPassword.disableSignUp`. Removed redundant code in `auth.ts` where `disableSignUp` is set.