### PR TITLE
Add CLI service to docker-compose.prod.yml

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -74,6 +74,14 @@ services:
       postgres:
         condition: service_healthy
 
+  cli:
+    image: ghcr.io/madflow/next-project-cli:main
+    environment:
+      - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+    depends_on:
+      postgres:
+        condition: service_healthy
+
   # https://hub.docker.com/_/postgres/
   postgres:
     image: "postgres:17-alpine"


### PR DESCRIPTION
- Added a new `cli` service definition.
- Specified the image from GitHub Container Registry.
- Set environment variables for database connection.
- Ensured the `cli` service depends on the `postgres` service being healthy.