### PR TITLE
Update restart policies and add cleanup flag to watchtower

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,6 +2,7 @@ services:
 
   caddy:
     image: caddy:2
+    restart: unless-stopped
     ports:
       - "80:80"
       - "443:443"
@@ -15,6 +16,7 @@ services:
 
   app:
     image: ghcr.io/madflow/next-project-app:main
+    restart: unless-stopped
     environment:
       - ANALYSIS_API_KEY=${ANALYSIS_API_KEY}
       - ANALYSIS_API_URL=${ANALYSIS_API_URL}
@@ -44,6 +46,7 @@ services:
 
   analysis:
     image: ghcr.io/madflow/next-project-analysis:main
+    restart: unless-stopped
     environment:
       -  ANALYSIS_DB_HOST=${POSTGRES_HOST}
       -  ANALYSIS_DB_PORT=${POSTGRES_PORT}
@@ -67,6 +70,7 @@ services:
 
   migrations:
     image: ghcr.io/madflow/next-project-db:main
+    restart: unless-stopped
     environment:
       - DOCKER_RUN_MIGRATIONS=1
       - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
@@ -76,6 +80,7 @@ services:
 
   cli:
     image: ghcr.io/madflow/next-project-cli:main
+    restart: unless-stopped
     environment:
       - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
     depends_on:
@@ -84,6 +89,7 @@ services:
 
   # https://hub.docker.com/_/postgres/
   postgres:
+    restart: unless-stopped
     image: "postgres:17-alpine"
     command: "postgres -c log_statement=all"
     healthcheck:
@@ -102,6 +108,7 @@ services:
   #https://mailpit.axllent.org/docs/install/docker/
   smtp:
     image: axllent/mailpit
+    restart: unless-stopped
     environment:
       MP_WEBROOT: /__mail/
       MP_MAX_MESSAGES: 5000

--- a/docker-compose.watchtower.yml
+++ b/docker-compose.watchtower.yml
@@ -3,4 +3,4 @@ services:
     image: containrrr/watchtower
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-    command: --interval 300
+    command: --interval 300 --cleanup


### PR DESCRIPTION
Restart services with `unless-stopped` policy for better stability. Add `--cleanup` flag to watchtower to remove unused images.