### PR TITLE
Update entrypoint path for CLI Docker image

### DIFF
--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -17,7 +17,7 @@ RUN turbo prune @repo/cli --docker
 FROM base AS runner
 
 COPY --from=builder /app/out/full/ .
-COPY --from=builder /app/packages/database/docker/entrypoint.sh /entrypoint.sh
+COPY --from=builder /app/packages/cli/docker/entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/bin/sh"]


### PR DESCRIPTION
The Dockerfile now correctly copies the entrypoint script from the builder stage to the runner stage. This ensures that the correct entrypoint script is used when running the CLI container.