### PR TITLE
Update Dockerfile and entrypoint for CLI

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
   cli:
     build:
       context: .
-      dockerfile: ./apps/cli/Dockerfile
+      dockerfile: ./packages/cli/Dockerfile
     depends_on:
       postgres:
         condition: service_healthy

--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:22-alpine AS base
 
+RUN apk add --no-cache bash
+
 WORKDIR /app
 
 FROM base AS builder-base
@@ -18,6 +20,8 @@ FROM base AS runner
 
 COPY --from=builder /app/out/full/ .
 COPY --from=builder /app/packages/cli/docker/entrypoint.sh /entrypoint.sh
+RUN npm install
+RUN npm run build
 
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["/bin/sh"]
+CMD ["/bin/bash"]

--- a/packages/cli/docker/entrypoint.sh
+++ b/packages/cli/docker/entrypoint.sh
@@ -8,3 +8,6 @@ if [ -n "${DATABASE_URL:-}" ]; then
     echo "DATABASE_URL=${DATABASE_URL}" > /app/packages/cli/.env
 fi
 
+# Run the command
+exec "$@"
+


### PR DESCRIPTION
- Modify `docker-compose.yml` to use updated paths for Dockerfiles.
- Add `bash` package in `packages/cli/Dockerfile` for better compatibility with scripts.
- Adjust `entrypoint.sh` to run the provided command instead of a shell.