### PR TITLE
Set default missing values for dataset upload form

### DIFF
--- a/apps/web/src/components/admin/dataset/upload-form.tsx
+++ b/apps/web/src/components/admin/dataset/upload-form.tsx
@@ -102,7 +102,7 @@ export function DatasetUploadForm() {
       files: [],
       name: "",
       organizationId: "",
-      missingValues: [],
+      missingValues: ["-999", "-998"],
       description: "",
     },
   });


### PR DESCRIPTION
Initializes the `missingValues` array with specific defaults to ensure data consistency during uploads.