### PR TITLE
Fix pie chart orientation by setting start and end angles

### DIFF
--- a/apps/web/src/components/chart/pie-adhoc.tsx
+++ b/apps/web/src/components/chart/pie-adhoc.tsx
@@ -37,6 +37,8 @@ export function PieAdhoc({ variable, stats, ...props }: PieAdhocProps) {
     };
   });
 
+  console.log(rechartsData);
+
   return (
     <Card className="shadow-xs" {...props}>
       <CardHeader>
@@ -46,7 +48,7 @@ export function PieAdhoc({ variable, stats, ...props }: PieAdhocProps) {
         <ChartContainer config={chartConfig} ref={ref} data-export-filename={variable.name}>
           <PieChart>
             <ChartTooltip cursor={false} content={<ChartTooltipContent hideLabel nameKey="label" />} />
-            <Pie data={rechartsData} dataKey="count" nameKey="label" />
+            <Pie data={rechartsData} dataKey="count" nameKey="label" startAngle={90} endAngle={-270} />
             <ChartLegend
               fontSize={10}
               content={<ChartLegendContent nameKey="label" />}


### PR DESCRIPTION
RechartsData is logged to the console. Pie chart now starts at 90 degrees and ends at -270 degrees for correct orientation.