### PR TITLE
Enhance frequency table with value labels and sorting

### DIFF
--- a/apps/analysis/analysis/web/api/datasets/routes.py
+++ b/apps/analysis/analysis/web/api/datasets/routes.py
@@ -233,7 +233,8 @@ async def get_dataset_stats(
                 stats = stats_service.describe_var(
                     df,
                     var_request.variable,
-                    missing_values=dataset_variable.missing_values,
+                    missing_values=dataset_variable.missing_values,  # type: ignore
+                    value_labels=dataset_variable.value_labels,  # type: ignore
                 )
                 results.append({"variable": var_request.variable, "stats": stats})
             except ValueError as e:


### PR DESCRIPTION
- Add value_labels parameter to describe_var method to ensure all labeled values appear in frequency table
- Exclude missing values from frequency table when value_labels are provided
- Sort frequency table by value in ascending order (numeric values first, then alphabetic)
- Include comprehensive tests for value labels handling and sorting functionality
- Pass value_labels from API to statistics service for complete integration
- Maintain backward compatibility when value_labels is None