### PR TITLE
Make chart percentage labels translatable

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -455,6 +455,7 @@
     "mean": "Arithmetisches Mittel",
     "median": "Median",
     "min": "Minimum",
+    "percent": "Prozent",
     "stdev": "Standardabweichung"
   },
   "dataset": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -455,6 +455,7 @@
     "mean": "Mean",
     "median": "Median",
     "min": "Min",
+    "percent": "Percent",
     "stdev": "Stdev"
   },
   "dataset": {

--- a/apps/web/src/components/chart/bar-adhoc.tsx
+++ b/apps/web/src/components/chart/bar-adhoc.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { DownloadIcon } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
@@ -10,20 +11,22 @@ import { type DatasetVariable } from "@/types/dataset-variable";
 import { StatsResponse } from "@/types/stats";
 import { Button } from "../ui/button";
 
-const chartConfig = {
-  count: {
-    label: "Anzahl",
-    color: "hsl(var(--chart-1))",
-  },
-} satisfies ChartConfig;
-
 type BarAdhocProps = {
   variable: DatasetVariable;
   stats: StatsResponse;
 } & React.HTMLAttributes<HTMLDivElement>;
 
 export function BarAdhoc({ variable, stats, ...props }: BarAdhocProps) {
+  const t = useTranslations("chartMetricsCard");
   const { ref, exportPNG } = useChartExport();
+  
+  const chartConfig = {
+    percentage: {
+      label: t("percent"),
+      color: "hsl(var(--chart-1))",
+    },
+  } satisfies ChartConfig;
+
   return (
     <Card className="shadow-xs" {...props}>
       <CardHeader>
@@ -35,8 +38,8 @@ export function BarAdhoc({ variable, stats, ...props }: BarAdhocProps) {
             <CartesianGrid vertical={false} />
             <XAxis dataKey="label" tickLine={false} tickMargin={10} axisLine={false} fontSize={10} />
             <ChartTooltip cursor={false} content={<ChartTooltipContent hideLabel />} />
-            <YAxis tickLine={false} tickMargin={10} axisLine={false} fontSize={10} />
-            <Bar dataKey="count" fill="var(--color-count)" radius={5} />
+            <YAxis domain={[0, 100]} tickLine={false} tickMargin={10} axisLine={false} fontSize={10} tickFormatter={(value) => `${value}%`} />
+            <Bar dataKey="percentage" fill="var(--color-percentage)" radius={5} />
           </BarChart>
         </ChartContainer>
       </CardContent>

--- a/apps/web/src/components/chart/horizontal-bar-adhoc.tsx
+++ b/apps/web/src/components/chart/horizontal-bar-adhoc.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { DownloadIcon } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
@@ -10,20 +11,22 @@ import { type DatasetVariable } from "@/types/dataset-variable";
 import { StatsResponse } from "@/types/stats";
 import { Button } from "../ui/button";
 
-const chartConfig = {
-  count: {
-    label: "Anzahl",
-    color: "hsl(var(--chart-1))",
-  },
-} satisfies ChartConfig;
-
 type BarAdhocProps = {
   variable: DatasetVariable;
   stats: StatsResponse;
 } & React.HTMLAttributes<HTMLDivElement>;
 
 export function HorizontalBarAdhoc({ variable, stats, ...props }: BarAdhocProps) {
+  const t = useTranslations("chartMetricsCard");
   const { ref, exportPNG } = useChartExport();
+  
+  const chartConfig = {
+    percentage: {
+      label: t("percent"),
+      color: "hsl(var(--chart-1))",
+    },
+  } satisfies ChartConfig;
+
   return (
     <Card className="shadow-xs" {...props}>
       <CardHeader>
@@ -40,7 +43,7 @@ export function HorizontalBarAdhoc({ variable, stats, ...props }: BarAdhocProps)
             accessibilityLayer
             data={transformToRechartsBarData(variable, stats)}>
             <CartesianGrid vertical={true} horizontal={false} />
-            <XAxis dataKey="count" type="number" tickLine={false} tickMargin={10} axisLine={false} fontSize={10} />
+            <XAxis domain={[0, 100]} dataKey="percentage" type="number" tickLine={false} tickMargin={10} axisLine={false} fontSize={10} tickFormatter={(value) => `${value}%`} />
             <YAxis
               dataKey="label"
               type="category"
@@ -50,7 +53,7 @@ export function HorizontalBarAdhoc({ variable, stats, ...props }: BarAdhocProps)
               fontSize={10}
               width={200}
             />
-            <Bar dataKey="count" fill="var(--color-count)" radius={5} />
+            <Bar dataKey="percentage" fill="var(--color-percentage)" radius={5} />
             <ChartTooltip cursor={false} content={<ChartTooltipContent hideLabel />} />
           </BarChart>
         </ChartContainer>

--- a/apps/web/src/components/chart/pie-adhoc.tsx
+++ b/apps/web/src/components/chart/pie-adhoc.tsx
@@ -47,8 +47,8 @@ export function PieAdhoc({ variable, stats, ...props }: PieAdhocProps) {
       <CardContent>
         <ChartContainer config={chartConfig} ref={ref} data-export-filename={variable.name}>
           <PieChart>
-            <ChartTooltip cursor={false} content={<ChartTooltipContent hideLabel nameKey="label" />} />
-            <Pie data={rechartsData} dataKey="count" nameKey="label" startAngle={90} endAngle={-270} />
+            <ChartTooltip cursor={false} content={<ChartTooltipContent nameKey="label" />} />
+            <Pie data={rechartsData} dataKey="percentage" nameKey="label" startAngle={90} endAngle={-270} />
             <ChartLegend
               fontSize={10}
               content={<ChartLegendContent nameKey="label" />}

--- a/apps/web/src/components/ui/chart.tsx
+++ b/apps/web/src/components/ui/chart.tsx
@@ -2,9 +2,9 @@
 
 import * as React from "react";
 import * as RechartsPrimitive from "recharts";
-import { cn } from "@/lib/utils";
-import { useOrganizationTheme } from "@/context/organization-theme-context";
 import { ChartThemeContext } from "@/components/active-theme";
+import { useOrganizationTheme } from "@/context/organization-theme-context";
+import { cn } from "@/lib/utils";
 
 // Format: { THEME_NAME: CSS_SELECTOR }
 const THEMES = { light: "", dark: ".dark" } as const;
@@ -66,13 +66,13 @@ const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
   const { resolveTheme } = useOrganizationTheme();
   const activeThemeName = React.useContext(ChartThemeContext);
   const { theme: activeTheme } = resolveTheme(activeThemeName);
-  
+
   const colorConfig = Object.entries(config).filter(([, config]) => config.theme || config.color);
 
   // Convert hex to hsl for CSS variables
   const hexToHsl = (hex: string) => {
-    if (!hex.startsWith('#')) return hex; // Return as-is if not hex
-    
+    if (!hex.startsWith("#")) return hex; // Return as-is if not hex
+
     const r = parseInt(hex.slice(1, 3), 16) / 255;
     const g = parseInt(hex.slice(3, 5), 16) / 255;
     const b = parseInt(hex.slice(5, 7), 16) / 255;
@@ -88,9 +88,15 @@ const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
       const d = max - min;
       s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
       switch (max) {
-        case r: h = (g - b) / d + (g < b ? 6 : 0); break;
-        case g: h = (b - r) / d + 2; break;
-        case b: h = (r - g) / d + 4; break;
+        case r:
+          h = (g - b) / d + (g < b ? 6 : 0);
+          break;
+        case g:
+          h = (b - r) / d + 2;
+          break;
+        case b:
+          h = (r - g) / d + 4;
+          break;
       }
       h! /= 6;
     }
@@ -107,37 +113,43 @@ const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
 ${prefix} [data-chart=${id}] {
 ${[
   // Default chart colors (chart-1 to chart-6) - can be overridden by organization themes
-  ...(theme === 'light' ? [
-    `  --chart-1: ${activeTheme?.chartColors?.['chart-1'] ? hexToHsl(activeTheme.chartColors['chart-1']) : '220 70% 50%'};`,
-    `  --chart-2: ${activeTheme?.chartColors?.['chart-2'] ? hexToHsl(activeTheme.chartColors['chart-2']) : '160 60% 45%'};`,
-    `  --chart-3: ${activeTheme?.chartColors?.['chart-3'] ? hexToHsl(activeTheme.chartColors['chart-3']) : '30 80% 55%'};`,
-    `  --chart-4: ${activeTheme?.chartColors?.['chart-4'] ? hexToHsl(activeTheme.chartColors['chart-4']) : '280 65% 60%'};`,
-    `  --chart-5: ${activeTheme?.chartColors?.['chart-5'] ? hexToHsl(activeTheme.chartColors['chart-5']) : '340 75% 55%'};`,
-    `  --chart-6: ${activeTheme?.chartColors?.['chart-6'] ? hexToHsl(activeTheme.chartColors['chart-6']) : '200 65% 50%'};`,
-  ] : [
-    `  --chart-1: ${activeTheme?.chartColors?.['chart-1'] ? hexToHsl(activeTheme.chartColors['chart-1']) : '220 70% 50%'};`,
-    `  --chart-2: ${activeTheme?.chartColors?.['chart-2'] ? hexToHsl(activeTheme.chartColors['chart-2']) : '160 84% 39%'};`,
-    `  --chart-3: ${activeTheme?.chartColors?.['chart-3'] ? hexToHsl(activeTheme.chartColors['chart-3']) : '30 80% 55%'};`,
-    `  --chart-4: ${activeTheme?.chartColors?.['chart-4'] ? hexToHsl(activeTheme.chartColors['chart-4']) : '280 65% 60%'};`,
-    `  --chart-5: ${activeTheme?.chartColors?.['chart-5'] ? hexToHsl(activeTheme.chartColors['chart-5']) : '340 75% 55%'};`,
-    `  --chart-6: ${activeTheme?.chartColors?.['chart-6'] ? hexToHsl(activeTheme.chartColors['chart-6']) : '200 65% 50%'};`,
-  ]),
-  // Config-specific colors (--color-{key}) 
-  ...colorConfig.map(([key, itemConfig]) => {
-    let color: string | undefined;
-    
-    if (itemConfig.theme) {
-      color = itemConfig.theme[theme as keyof typeof itemConfig.theme];
-    } else if (itemConfig.color) {
-      color = itemConfig.color;
-    } else if (activeTheme?.chartColors?.[key]) {
-      // Use organization theme color for this key
-      color = activeTheme.chartColors[key];
-    }
-    
-    return color ? `  --color-${key}: ${color};` : null;
-  }).filter(Boolean)
-].filter(Boolean).join('\n')}
+  ...(theme === "light"
+    ? [
+        `  --chart-1: ${activeTheme?.chartColors?.["chart-1"] ? hexToHsl(activeTheme.chartColors["chart-1"]) : "220 70% 50%"};`,
+        `  --chart-2: ${activeTheme?.chartColors?.["chart-2"] ? hexToHsl(activeTheme.chartColors["chart-2"]) : "160 60% 45%"};`,
+        `  --chart-3: ${activeTheme?.chartColors?.["chart-3"] ? hexToHsl(activeTheme.chartColors["chart-3"]) : "30 80% 55%"};`,
+        `  --chart-4: ${activeTheme?.chartColors?.["chart-4"] ? hexToHsl(activeTheme.chartColors["chart-4"]) : "280 65% 60%"};`,
+        `  --chart-5: ${activeTheme?.chartColors?.["chart-5"] ? hexToHsl(activeTheme.chartColors["chart-5"]) : "340 75% 55%"};`,
+        `  --chart-6: ${activeTheme?.chartColors?.["chart-6"] ? hexToHsl(activeTheme.chartColors["chart-6"]) : "200 65% 50%"};`,
+      ]
+    : [
+        `  --chart-1: ${activeTheme?.chartColors?.["chart-1"] ? hexToHsl(activeTheme.chartColors["chart-1"]) : "220 70% 50%"};`,
+        `  --chart-2: ${activeTheme?.chartColors?.["chart-2"] ? hexToHsl(activeTheme.chartColors["chart-2"]) : "160 84% 39%"};`,
+        `  --chart-3: ${activeTheme?.chartColors?.["chart-3"] ? hexToHsl(activeTheme.chartColors["chart-3"]) : "30 80% 55%"};`,
+        `  --chart-4: ${activeTheme?.chartColors?.["chart-4"] ? hexToHsl(activeTheme.chartColors["chart-4"]) : "280 65% 60%"};`,
+        `  --chart-5: ${activeTheme?.chartColors?.["chart-5"] ? hexToHsl(activeTheme.chartColors["chart-5"]) : "340 75% 55%"};`,
+        `  --chart-6: ${activeTheme?.chartColors?.["chart-6"] ? hexToHsl(activeTheme.chartColors["chart-6"]) : "200 65% 50%"};`,
+      ]),
+  // Config-specific colors (--color-{key})
+  ...colorConfig
+    .map(([key, itemConfig]) => {
+      let color: string | undefined;
+
+      if (itemConfig.theme) {
+        color = itemConfig.theme[theme as keyof typeof itemConfig.theme];
+      } else if (itemConfig.color) {
+        color = itemConfig.color;
+      } else if (activeTheme?.chartColors?.[key]) {
+        // Use organization theme color for this key
+        color = activeTheme.chartColors[key];
+      }
+
+      return color ? `  --color-${key}: ${color};` : null;
+    })
+    .filter(Boolean),
+]
+  .filter(Boolean)
+  .join("\n")}
 }
 `
           )
@@ -252,7 +264,7 @@ function ChartTooltipContent({
                     )}>
                     <div className="grid gap-1.5">
                       {nestLabel ? tooltipLabel : null}
-                      <span className="text-muted-foreground">{itemConfig?.label || item.name}</span>
+                      <span className="text-muted-foreground mr-2">{itemConfig?.label || item.name}</span>
                     </div>
                     {item.value && (
                       <span className="text-foreground font-mono font-medium tabular-nums">


### PR DESCRIPTION
Add internationalization support for percentage labels in adhoc chart components by moving hardcoded 'Prozent' text to translation files and implementing useTranslations hook.