### PR TITLE
Add mean bar chart component to AdhocChart

### DIFF
--- a/apps/web/src/components/chart/mean-bar-adhoc.tsx
+++ b/apps/web/src/components/chart/mean-bar-adhoc.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { DownloadIcon } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+import { useChartExport } from "@/hooks/use-chart-export";
+import { type DatasetVariable } from "@/types/dataset-variable";
+import { StatsResponse } from "@/types/stats";
+import { Button } from "../ui/button";
+
+type MeanBarAdhocProps = {
+  variable: DatasetVariable;
+  stats: StatsResponse;
+  renderAsContent?: boolean;
+} & React.HTMLAttributes<HTMLDivElement>;
+
+export function MeanBarAdhoc({ variable, stats, renderAsContent, ...props }: MeanBarAdhocProps) {
+  const t = useTranslations("chartMetricsCard");
+  const { ref, exportPNG } = useChartExport();
+
+  // Find the stats for this variable
+  const variableStats = stats.find(item => item.variable === variable.name)?.stats;
+  if (!variableStats) return null;
+
+  // Create data for mean and median bars
+  const chartData = [
+    {
+      label: t("mean"),
+      value: variableStats.mean,
+    },
+    {
+      label: t("median"),
+      value: variableStats.median,
+    },
+  ];
+
+  // Use the max value from stats for the domain
+  const maxValue = variableStats.max;
+
+  const chartConfig = {
+    value: {
+      label: "Value",
+      color: "hsl(var(--chart-1))",
+    },
+  } satisfies ChartConfig;
+
+  const chartContent = (
+    <ChartContainer config={chartConfig} ref={ref} data-export-filename={variable.name}>
+      <BarChart
+        layout="vertical"
+        margin={{
+          left: 0,
+        }}
+        barCategoryGap={1}
+        accessibilityLayer
+        data={chartData}>
+        <CartesianGrid vertical={true} horizontal={false} />
+        <XAxis
+          domain={[0, maxValue]}
+          dataKey="value"
+          type="number"
+          tickLine={false}
+          tickMargin={10}
+          axisLine={false}
+          fontSize={10}
+        />
+        <YAxis
+          dataKey="label"
+          type="category"
+          tickLine={false}
+          tickMargin={10}
+          axisLine={false}
+          fontSize={10}
+          width={200}
+        />
+        <Bar dataKey="value" fill="var(--color-value)" radius={5} />
+        <ChartTooltip cursor={false} content={<ChartTooltipContent hideLabel />} />
+      </BarChart>
+    </ChartContainer>
+  );
+
+  if (renderAsContent) {
+    return chartContent;
+  }
+
+  return (
+    <Card className="shadow-xs" {...props}>
+      <CardHeader>
+        <CardTitle>{variable.label ?? variable.name}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {chartContent}
+      </CardContent>
+
+      <CardFooter>
+        <Button className="cursor-pointer" variant="outline" onClick={exportPNG}>
+          <DownloadIcon className="h-4 w-4" />
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/apps/web/src/components/chart/metrics-cards.tsx
+++ b/apps/web/src/components/chart/metrics-cards.tsx
@@ -9,6 +9,7 @@ import { StatsResponse } from "@/types/stats";
 type BarAdhocProps = {
   variable: DatasetVariable;
   stats: StatsResponse;
+  renderAsContent?: boolean;
 } & React.HTMLAttributes<HTMLDivElement>;
 
 function formatDecimal(value?: number) {
@@ -16,51 +17,62 @@ function formatDecimal(value?: number) {
   return new Intl.NumberFormat("de-DE", { style: "decimal" }).format(value);
 }
 
-export function MetricsCards({ variable, stats, ...props }: BarAdhocProps) {
+export function MetricsCards({ variable, stats, renderAsContent, ...props }: BarAdhocProps) {
   const t = useTranslations("chartMetricsCard");
   const variableStats = getVariableStats(variable, stats);
+  
+  const content = (
+    <div className="grid grid-cols-3 gap-2">
+      <Card>
+        <CardHeader>
+          <CardDescription>{t("count")}</CardDescription>
+          <CardTitle>{variableStats?.count}</CardTitle>
+        </CardHeader>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardDescription>{t("mean")}</CardDescription>
+          <CardTitle>{formatDecimal(variableStats?.mean)}</CardTitle>
+        </CardHeader>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardDescription>{t("stdev")}</CardDescription>
+          <CardTitle>{formatDecimal(variableStats?.std)}</CardTitle>
+        </CardHeader>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardDescription>{t("median")}</CardDescription>
+          <CardTitle>{variableStats?.median}</CardTitle>
+        </CardHeader>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardDescription>{t("min")}</CardDescription>
+          <CardTitle>{variableStats?.min}</CardTitle>
+        </CardHeader>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardDescription>{t("max")}</CardDescription>
+          <CardTitle>{variableStats?.max}</CardTitle>
+        </CardHeader>
+      </Card>
+    </div>
+  );
+
+  if (renderAsContent) {
+    return content;
+  }
+
   return (
     <Card className="shadow-xs" {...props}>
       <CardHeader>
         <CardTitle>{variable.label ?? variable.name}</CardTitle>
       </CardHeader>
-      <CardContent className="grid grid-cols-3 gap-2">
-        <Card>
-          <CardHeader>
-            <CardDescription>{t("count")}</CardDescription>
-            <CardTitle>{variableStats?.count}</CardTitle>
-          </CardHeader>
-        </Card>
-        <Card>
-          <CardHeader>
-            <CardDescription>{t("mean")}</CardDescription>
-            <CardTitle>{formatDecimal(variableStats?.mean)}</CardTitle>
-          </CardHeader>
-        </Card>
-        <Card>
-          <CardHeader>
-            <CardDescription>{t("stdev")}</CardDescription>
-            <CardTitle>{formatDecimal(variableStats?.std)}</CardTitle>
-          </CardHeader>
-        </Card>
-        <Card>
-          <CardHeader>
-            <CardDescription>{t("median")}</CardDescription>
-            <CardTitle>{variableStats?.median}</CardTitle>
-          </CardHeader>
-        </Card>
-        <Card>
-          <CardHeader>
-            <CardDescription>{t("min")}</CardDescription>
-            <CardTitle>{variableStats?.min}</CardTitle>
-          </CardHeader>
-        </Card>
-        <Card>
-          <CardHeader>
-            <CardDescription>{t("max")}</CardDescription>
-            <CardTitle>{variableStats?.max}</CardTitle>
-          </CardHeader>
-        </Card>
+      <CardContent>
+        {content}
       </CardContent>
     </Card>
   );

--- a/apps/web/src/types/stats.ts
+++ b/apps/web/src/types/stats.ts
@@ -43,4 +43,4 @@ export type VariableStats = z.infer<typeof VariableStatsSchema>;
 export type StatsResponseItem = z.infer<typeof StatsResponseItemSchema>;
 export type StatsResponse = z.infer<typeof StatsResponseSchema>;
 
-export type AnalysisChartType = "bar" | "horizontalBar" | "pie" | "metrics";
+export type AnalysisChartType = "bar" | "horizontalBar" | "pie" | "metrics" | "meanBar";


### PR DESCRIPTION
Introduce a new component `MeanBarAdhoc` for displaying mean bar charts. This component is integrated into the existing `AdhocChart` to handle the display of mean bars based on dataset variables and statistics.

- Added `mean-bar-adhoc.tsx` file with the `MeanBarAdhoc` component.
- Updated `adhoc-chart.tsx` to include `MeanBarAdhoc` and conditionally render it based on the selected chart type.