### PR TITLE
Extract dataset creation logic into shared service

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -116,8 +116,6 @@ jobs:
       run: npm run build
     - name: Migrate 
       run: npm run db:migrate
-    - name: Seed 
-      run: npm run seed
     - name: Run App
       run: |
         npm run start | tee app.log 2>&1 &
@@ -134,6 +132,8 @@ jobs:
           echo "Still waiting for the application to be ready..."
           sleep 10
         done
+    - name: Seed 
+      run: npm run seed
     - name: Run Playwright tests
       run:  npm run e2e
     - uses: actions/upload-artifact@v4

--- a/apps/web/src/actions/dataset.ts
+++ b/apps/web/src/actions/dataset.ts
@@ -1,46 +1,17 @@
 "use server";
 
-import { S3ServiceException } from "@aws-sdk/client-s3";
 import { eq } from "drizzle-orm";
 import { headers } from "next/headers";
 import { defaultClient as db } from "@repo/database/clients";
-import {
-  CreateDatasetVariableData,
-  DatasetVariableValueLabel,
-  UpdateDatasetData,
-  dataset,
-  datasetProject,
-  datasetVariable,
-  insertDatasetVariableSchema,
-} from "@repo/database/schema";
+import { UpdateDatasetData, dataset, datasetProject } from "@repo/database/schema";
 import { deleteDataset } from "@/dal/dataset";
-import { createAnalysisClient } from "@/lib/analysis-client";
 import { USER_ADMIN_ROLE, auth } from "@/lib/auth";
 import {
-  ServerActionException,
   ServerActionNotAuthorizedException,
-  ServerActionValidationException,
 } from "@/lib/exception";
-import { putDataset } from "@/lib/storage";
-import { datasetReadResponseSchema } from "@/types/dataset";
+import { createDataset, CreateDatasetResult } from "@/lib/dataset-service";
 
-const ALLOWED_FILE_TYPES = [
-  "application/x-spss-sav", // .sav
-  // "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", // .xlsx
-  // "text/csv",
-  // "application/vnd.oasis.opendocument.spreadsheet", // .ods
-  // "application/octet-stream", // .parquet
-];
-
-const MAX_FILE_SIZE = 100 * 1024 * 1024; // 100MB
-
-export type UploadDatasetResult = {
-  success: boolean;
-  datasetId?: string;
-  key?: string;
-  error?: string;
-  details?: unknown;
-};
+export type UploadDatasetResult = CreateDatasetResult;
 
 type UploadDatasetParams = {
   file: File;
@@ -78,113 +49,23 @@ export async function uploadDataset({
     headers: await headers(),
   });
 
-  try {
-    if (!session?.user) {
-      throw new ServerActionNotAuthorizedException("Unauthorized");
-    }
-
-    if (session.user.role !== USER_ADMIN_ROLE) {
-      throw new ServerActionNotAuthorizedException("Unauthorized");
-    }
-
-    if (!ALLOWED_FILE_TYPES.includes(contentType) && !file.name.match(/\.(sav)$/i)) {
-      throw new ServerActionValidationException("Invalid file type. Allowed types: .sav");
-    }
-
-    if (file.size > MAX_FILE_SIZE) {
-      throw new ServerActionValidationException(`File too large. Maximum size: ${MAX_FILE_SIZE / 1024 / 1024}MB`);
-    }
-
-    const { fileHash, fileExtension, s3Key } = await putDataset(file, contentType, organizationId, session.user.id);
-
-    // Save to database
-    const result = await db
-      .insert(dataset)
-      .values({
-        name: name,
-        filename: file.name,
-        fileType: fileExtension,
-        fileSize: file.size,
-        fileHash: fileHash,
-        storageKey: s3Key,
-        organizationId,
-        description: description || undefined,
-        uploadedAt: new Date(),
-        updatedAt: new Date(),
-        createdAt: new Date(),
-      })
-      .returning({ id: dataset.id });
-
-    if (!result[0]?.id) {
-      throw new ServerActionException("Failed to save file metadata to database");
-    }
-
-    const { fetch: analysisFetch } = createAnalysisClient();
-    const fileMetadataResp = await analysisFetch(`/datasets/${result[0]?.id}/metadata`);
-    if (!fileMetadataResp.ok) {
-      throw new ServerActionException("Failed to fetch file metadata from analysis service");
-    }
-    const metadataResult = await fileMetadataResp.json();
-    const datasetReadResponse = datasetReadResponseSchema.safeParse(metadataResult);
-    if (!datasetReadResponse.success) {
-      console.error(datasetReadResponse.error);
-      throw new ServerActionException("Failed to fetch file metadata from analysis service");
-    }
-
-    const { metadata } = datasetReadResponse.data;
-
-    const insertValues: CreateDatasetVariableData[] = [];
-    for (const columnName of metadata.column_names) {
-      const columnLabel = metadata.column_names_to_labels[columnName] as string;
-
-      const variableValues = metadata.variable_value_labels[columnName] ?? {};
-
-      const columnValueLabels: DatasetVariableValueLabel = {};
-      for (const [value, label] of Object.entries(variableValues)) {
-        columnValueLabels[value] = label;
-      }
-
-      const columnLabels = {
-        default: columnLabel,
-      };
-
-      const insertVariable = insertDatasetVariableSchema.parse({
-        name: columnName,
-        label: columnLabel,
-        measure: metadata.variable_measure[columnName],
-        type: metadata.readstat_variable_types[columnName],
-        variableLabels: columnLabels,
-        valueLabels: columnValueLabels,
-        datasetId: result[0].id,
-        missingValues: missingValues ?? null,
-      } as CreateDatasetVariableData);
-
-      insertValues.push(insertVariable);
-    }
-
-    await db.insert(datasetVariable).values(insertValues);
-
-    return {
-      success: true,
-      datasetId: result[0].id,
-      key: s3Key,
-    };
-  } catch (error) {
-    console.error("Error uploading dataset:", error);
-
-    let errorMessage = "Failed to upload file";
-    if (error instanceof S3ServiceException) {
-      errorMessage = `S3 Error: ${error.name} - ${error.message}`;
-    } else if (error instanceof Error) {
-      errorMessage = error.message;
-    }
-
-    return {
-      success: false,
-      error: errorMessage,
-      details: error instanceof Error ? error.stack : undefined,
-    };
+  if (!session?.user) {
+    throw new ServerActionNotAuthorizedException("Unauthorized");
   }
+
+  if (session.user.role !== USER_ADMIN_ROLE) {
+    throw new ServerActionNotAuthorizedException("Unauthorized");
+  }
+
+  return await createDataset({
+    file,
+    name,
+    organizationId,
+    description,
+    contentType,
+    missingValues,
+    userId: session.user.id,
+  });
 }
 
 export async function remove(datasetId: string) {

--- a/apps/web/src/lib/dataset-service.ts
+++ b/apps/web/src/lib/dataset-service.ts
@@ -1,0 +1,186 @@
+import { S3ServiceException } from "@aws-sdk/client-s3";
+import { defaultClient as db } from "@repo/database/clients";
+import {
+  CreateDatasetVariableData,
+  DatasetVariableValueLabel,
+  dataset,
+  datasetVariable,
+  insertDatasetVariableSchema,
+} from "@repo/database/schema";
+import {
+  ServerActionException,
+  ServerActionValidationException,
+} from "@/lib/exception";
+import { putDataset } from "@/lib/storage";
+import { datasetReadResponseSchema } from "@/types/dataset";
+import { env } from "@/env";
+
+const ALLOWED_FILE_TYPES = [
+  "application/x-spss-sav", // .sav
+  // "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", // .xlsx
+  // "text/csv",
+  // "application/vnd.oasis.opendocument.spreadsheet", // .ods
+  // "application/octet-stream", // .parquet
+];
+
+const MAX_FILE_SIZE = 100 * 1024 * 1024; // 100MB
+
+export type CreateDatasetResult = {
+  success: boolean;
+  datasetId?: string;
+  key?: string;
+  error?: string;
+  details?: unknown;
+};
+
+type CreateDatasetParams = {
+  file: File;
+  name: string;
+  organizationId: string;
+  description?: string;
+  contentType: string;
+  missingValues: string[] | null;
+  userId?: string;
+  id?: string; // Optional predefined ID for seeding
+};
+
+// Create analysis client without "server-only" import for seeding compatibility
+function createAnalysisClientForSeeding() {
+  const baseURL = env.ANALYSIS_API_URL;
+  const apiKey = env.ANALYSIS_API_KEY;
+
+  return {
+    fetch: async (path: string, options?: RequestInit) => {
+      const url = `${baseURL}${path}`;
+      return fetch(url, {
+        ...options,
+        headers: {
+          "Content-Type": "application/json",
+          "X-API-Key": apiKey,
+          ...options?.headers,
+        },
+      });
+    },
+  };
+}
+
+export async function createDataset({
+  file,
+  name,
+  organizationId,
+  description,
+  contentType,
+  missingValues,
+  userId,
+  id,
+}: CreateDatasetParams): Promise<CreateDatasetResult> {
+  try {
+    // Validate file type
+    if (!ALLOWED_FILE_TYPES.includes(contentType) && !file.name.match(/\.(sav)$/i)) {
+      throw new ServerActionValidationException("Invalid file type. Allowed types: .sav");
+    }
+
+    // Validate file size
+    if (file.size > MAX_FILE_SIZE) {
+      throw new ServerActionValidationException(`File too large. Maximum size: ${MAX_FILE_SIZE / 1024 / 1024}MB`);
+    }
+
+    // Upload file to S3
+    const { fileHash, fileExtension, s3Key } = await putDataset(file, contentType, organizationId, userId);
+
+    // Save dataset to database
+    const datasetValues = {
+      name: name,
+      filename: file.name,
+      fileType: fileExtension,
+      fileSize: file.size,
+      fileHash: fileHash,
+      storageKey: s3Key,
+      organizationId,
+      description: description || undefined,
+      uploadedAt: new Date(),
+      updatedAt: new Date(),
+      createdAt: new Date(),
+      ...(id && { id }), // Include predefined ID if provided
+    };
+
+    const result = await db
+      .insert(dataset)
+      .values(datasetValues)
+      .returning({ id: dataset.id });
+
+    if (!result[0]?.id) {
+      throw new ServerActionException("Failed to save file metadata to database");
+    }
+
+    const datasetId = result[0].id;
+
+    // Fetch metadata from analysis service
+    const analysisClient = createAnalysisClientForSeeding();
+    const fileMetadataResp = await analysisClient.fetch(`/datasets/${datasetId}/metadata`);
+    if (!fileMetadataResp.ok) {
+      throw new ServerActionException("Failed to fetch file metadata from analysis service");
+    }
+    const metadataResult = await fileMetadataResp.json();
+    const datasetReadResponse = datasetReadResponseSchema.safeParse(metadataResult);
+    if (!datasetReadResponse.success) {
+      console.error(datasetReadResponse.error);
+      throw new ServerActionException("Failed to fetch file metadata from analysis service");
+    }
+
+    const { metadata } = datasetReadResponse.data;
+
+    // Create dataset variables
+    const insertValues: CreateDatasetVariableData[] = [];
+    for (const columnName of metadata.column_names) {
+      const columnLabel = metadata.column_names_to_labels[columnName] as string;
+
+      const variableValues = metadata.variable_value_labels[columnName] ?? {};
+
+      const columnValueLabels: DatasetVariableValueLabel = {};
+      for (const [value, label] of Object.entries(variableValues)) {
+        columnValueLabels[value] = label;
+      }
+
+      const columnLabels = {
+        default: columnLabel,
+      };
+
+      const insertVariable = insertDatasetVariableSchema.parse({
+        name: columnName,
+        label: columnLabel,
+        measure: metadata.variable_measure[columnName],
+        type: metadata.readstat_variable_types[columnName],
+        variableLabels: columnLabels,
+        valueLabels: columnValueLabels,
+        datasetId: datasetId,
+        missingValues: missingValues ?? null,
+      } as CreateDatasetVariableData);
+
+      insertValues.push(insertVariable);
+    }
+
+    await db.insert(datasetVariable).values(insertValues);
+
+    return {
+      success: true,
+      datasetId: datasetId,
+      key: s3Key,
+    };
+  } catch (error) {
+    console.error("Error creating dataset:", error);
+
+    let errorMessage = "Failed to create dataset";
+    if (error instanceof S3ServiceException) {
+      errorMessage = `S3 Error: ${error.name} - ${error.message}`;
+    } else if (error instanceof Error) {
+      errorMessage = error.message;
+    }
+
+    return {
+      success: false,
+      error: errorMessage,
+      details: error instanceof Error ? error.stack : undefined,
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- Extract shared dataset creation logic to eliminate code duplication between server actions and CLI seeding
- Create `dataset-service.ts` that handles file upload, validation, and variable metadata extraction in a reusable way
- Update server action to delegate to shared service while maintaining authentication and authorization
- Update seed script to use shared service, ensuring dataset variables are properly created during seeding (previously missing)

This resolves the issue where seeding and web app dataset creation had duplicated logic with different behavior, making it difficult to maintain consistency between CLI and web operations.