### PR TITLE
fix: restrict metrics card to double scale variables only

### DIFF
--- a/apps/web/src/components/chart/adhoc-chart.tsx
+++ b/apps/web/src/components/chart/adhoc-chart.tsx
@@ -61,10 +61,11 @@ export function AdhocChart({ variable, stats, ...props }: AdhocChartProps) {
       if (frequencyTableLength === 2) {
         availableCharts.push("bar");
       }
-      availableCharts.push("metrics");
     } else if (variable.measure === "scale") {
       availableCharts.push("meanBar");
-      availableCharts.push("metrics");
+      if (variable.type === "double") {
+        availableCharts.push("metrics");
+      }
     }
 
     return availableCharts;


### PR DESCRIPTION
## Summary
- Remove metrics chart option from ordinal variables entirely
- Add conditional check for scale variables to only show metrics when variable type is "double"