### PR TITLE
Fix chart type reset on variable selection in adhoc analysis

### DIFF
--- a/apps/web/src/components/chart/adhoc-chart.tsx
+++ b/apps/web/src/components/chart/adhoc-chart.tsx
@@ -10,7 +10,7 @@ import {
   SheetIcon,
 } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Bar, BarChart, CartesianGrid, Pie, PieChart, XAxis, YAxis } from "recharts";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -75,13 +75,29 @@ export function AdhocChart({ variable, stats, ...props }: AdhocChartProps) {
     return availableCharts;
   }
 
-  const availableChartTypes = getAvailableChartTypes(variable, stats);
-  const [selectedChartType, setSelectedChartType] = useState<AnalysisChartType>(() => {
+  function getDefaultChartType(availableChartTypes: AnalysisChartType[]): AnalysisChartType {
     if (availableChartTypes.includes("horizontalBar")) return "horizontalBar";
     if (availableChartTypes.includes("meanBar")) return "meanBar";
     if (availableChartTypes.includes("metrics")) return "metrics";
     return availableChartTypes[0] || "horizontalBar";
+  }
+
+  const availableChartTypes = getAvailableChartTypes(variable, stats);
+  const [selectedChartType, setSelectedChartType] = useState<AnalysisChartType>(() => {
+    return getDefaultChartType(availableChartTypes);
   });
+  
+  const prevVariableIdRef = useRef(variable.id);
+
+  useEffect(() => {
+    // Only reset when variable actually changes
+    if (prevVariableIdRef.current !== variable.id) {
+      const newAvailableChartTypes = getAvailableChartTypes(variable, stats);
+      const defaultChartType = getDefaultChartType(newAvailableChartTypes);
+      setSelectedChartType(defaultChartType);
+      prevVariableIdRef.current = variable.id;
+    }
+  }, [variable.id, variable, stats]); // Include all dependencies used inside
 
   const chartConfig = {
     percentage: {


### PR DESCRIPTION
## Summary

- Fix chart type preselection issue where previously selected chart type would persist when selecting a new variable
- Chart type now properly resets to the default type when a new variable is selected in adhoc analysis
- Users can still manually change chart types for the same variable without unwanted resets

## Changes

- Extract default chart type logic into reusable `getDefaultChartType()` function
- Add `useEffect` with `useRef` to track variable changes and reset chart type only when variable actually changes
- Avoid dependency array issues by using ref-based comparison instead of including `availableChartTypes` in dependencies

## Testing

- Verified with Playwright that chart type selection works correctly for same variable
- Verified that chart type resets to default when selecting different variables
- Confirmed no unintended resets during normal chart type changes