### PR TITLE
Add admin debug mode toggle with clean chart interface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ This project uses the following technologies:
 
 ## Rules for running commands
 
-- Use `make check` (not `npm run build`) to test the project and regenerate types.
+- **IMPORTANT:** Use `make check` (not `npm run build`) to test the project and regenerate types.
 - Always run `make check` after making significant changes to ensure code quality.
 
 ## Writing tasks and specs for agentic coding

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -958,6 +958,11 @@
     },
     "title": "Registrieren"
   },
+  "debugMode": {
+    "label": "Debug-Modus",
+    "enabled": "AN",
+    "disabled": "AUS"
+  },
   "themeSelector": {
     "colorThemes": "Farben",
     "label": "Design",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -958,6 +958,11 @@
     },
     "title": "Sign Up"
   },
+  "debugMode": {
+    "label": "Debug Mode",
+    "enabled": "ON",
+    "disabled": "OFF"
+  },
   "themeSelector": {
     "colorThemes": "Colors",
     "label": "Theme",

--- a/apps/web/src/components/chart/adhoc-chart.tsx
+++ b/apps/web/src/components/chart/adhoc-chart.tsx
@@ -46,6 +46,7 @@ import { Code } from "../ui/code";
 import { HorizontalStackedBarAdhoc } from "./horizontal-stacked-bar-adhoc";
 import { MeanBarAdhoc } from "./mean-bar-adhoc";
 import { MetricsCards } from "./metrics-cards";
+import { useAppContext } from "@/context/app-context";
 
 type AdhocChartProps = {
   variable: DatasetVariable;
@@ -57,6 +58,7 @@ export function AdhocChart({ variable, stats, datasetId, ...props }: AdhocChartP
   const t = useTranslations("projectAdhocAnalysis");
   const tChart = useTranslations("chartMetricsCard");
   const { ref, exportPNG } = useChartExport();
+  const { debugMode } = useAppContext();
 
   // Fetch split variables when datasetId is provided
   const { data: splitVariablesResponse } = useQueryApi<{ rows: DatasetVariable[] }>({
@@ -334,11 +336,13 @@ export function AdhocChart({ variable, stats, datasetId, ...props }: AdhocChartP
     return (
       <div {...props}>
         <Tabs defaultValue="chart" className="w-full">
-          <TabsList>
-            <TabsTrigger value="chart">{t("tabs.chart")}</TabsTrigger>
-            <TabsTrigger value="variable">{t("tabs.variable")}</TabsTrigger>
-            <TabsTrigger value="stats">{t("tabs.stats")}</TabsTrigger>
-          </TabsList>
+          {debugMode && (
+            <TabsList>
+              <TabsTrigger value="chart">{t("tabs.chart")}</TabsTrigger>
+              <TabsTrigger value="variable">{t("tabs.variable")}</TabsTrigger>
+              <TabsTrigger value="stats">{t("tabs.stats")}</TabsTrigger>
+            </TabsList>
+          )}
           <TabsContent value="chart">
             <Card className="shadow-xs">
               <CardHeader>
@@ -378,32 +382,36 @@ export function AdhocChart({ variable, stats, datasetId, ...props }: AdhocChartP
               )}
             </Card>
           </TabsContent>
-          <TabsContent value="variable">
-            <Card className="shadow-xs">
-              <CardHeader>
-                <CardTitle>{variable.label ?? variable.name}</CardTitle>
-                {getSplitVariableDescription(variable, stats) && (
-                  <CardDescription>{getSplitVariableDescription(variable, stats)}</CardDescription>
-                )}
-              </CardHeader>
-              <CardContent>
-                <Code>{JSON.stringify(variable, null, 2)}</Code>
-              </CardContent>
-            </Card>
-          </TabsContent>
-          <TabsContent value="stats">
-            <Card className="shadow-xs">
-              <CardHeader>
-                <CardTitle>{variable.label ?? variable.name}</CardTitle>
-                {getSplitVariableDescription(variable, stats) && (
-                  <CardDescription>{getSplitVariableDescription(variable, stats)}</CardDescription>
-                )}
-              </CardHeader>
-              <CardContent>
-                <Code>{JSON.stringify(stats, null, 2)}</Code>
-              </CardContent>
-            </Card>
-          </TabsContent>
+          {debugMode && (
+            <TabsContent value="variable">
+              <Card className="shadow-xs">
+                <CardHeader>
+                  <CardTitle>{variable.label ?? variable.name}</CardTitle>
+                  {getSplitVariableDescription(variable, stats) && (
+                    <CardDescription>{getSplitVariableDescription(variable, stats)}</CardDescription>
+                  )}
+                </CardHeader>
+                <CardContent>
+                  <Code>{JSON.stringify(variable, null, 2)}</Code>
+                </CardContent>
+              </Card>
+            </TabsContent>
+          )}
+          {debugMode && (
+            <TabsContent value="stats">
+              <Card className="shadow-xs">
+                <CardHeader>
+                  <CardTitle>{variable.label ?? variable.name}</CardTitle>
+                  {getSplitVariableDescription(variable, stats) && (
+                    <CardDescription>{getSplitVariableDescription(variable, stats)}</CardDescription>
+                  )}
+                </CardHeader>
+                <CardContent>
+                  <Code>{JSON.stringify(stats, null, 2)}</Code>
+                </CardContent>
+              </Card>
+            </TabsContent>
+          )}
         </Tabs>
       </div>
     );
@@ -412,11 +420,13 @@ export function AdhocChart({ variable, stats, datasetId, ...props }: AdhocChartP
   return (
     <div {...props}>
       <Tabs defaultValue="chart" className="w-full">
-        <TabsList>
-          <TabsTrigger value="chart">{t("tabs.chart")}</TabsTrigger>
-          <TabsTrigger value="variable">{t("tabs.variable")}</TabsTrigger>
-          <TabsTrigger value="stats">{t("tabs.stats")}</TabsTrigger>
-        </TabsList>
+        {debugMode && (
+          <TabsList>
+            <TabsTrigger value="chart">{t("tabs.chart")}</TabsTrigger>
+            <TabsTrigger value="variable">{t("tabs.variable")}</TabsTrigger>
+            <TabsTrigger value="stats">{t("tabs.stats")}</TabsTrigger>
+          </TabsList>
+        )}
         <TabsContent value="chart">
           <Card className="shadow-xs">
             <CardHeader>
@@ -448,32 +458,36 @@ export function AdhocChart({ variable, stats, datasetId, ...props }: AdhocChartP
             </CardFooter>
           </Card>
         </TabsContent>
-        <TabsContent value="variable">
-          <Card className="shadow-xs">
-            <CardHeader>
-              <CardTitle>{variable.label ?? variable.name}</CardTitle>
-              {getSplitVariableDescription(variable, stats) && (
-                <CardDescription>{getSplitVariableDescription(variable, stats)}</CardDescription>
-              )}
-            </CardHeader>
-            <CardContent>
-              <Code>{JSON.stringify(variable, null, 2)}</Code>
-            </CardContent>
-          </Card>
-        </TabsContent>
-        <TabsContent value="stats">
-          <Card className="shadow-xs">
-            <CardHeader>
-              <CardTitle>{variable.label ?? variable.name}</CardTitle>
-              {getSplitVariableDescription(variable, stats) && (
-                <CardDescription>{getSplitVariableDescription(variable, stats)}</CardDescription>
-              )}
-            </CardHeader>
-            <CardContent>
-              <Code>{JSON.stringify(stats, null, 2)}</Code>
-            </CardContent>
-          </Card>
-        </TabsContent>
+        {debugMode && (
+          <TabsContent value="variable">
+            <Card className="shadow-xs">
+              <CardHeader>
+                <CardTitle>{variable.label ?? variable.name}</CardTitle>
+                {getSplitVariableDescription(variable, stats) && (
+                  <CardDescription>{getSplitVariableDescription(variable, stats)}</CardDescription>
+                )}
+              </CardHeader>
+              <CardContent>
+                <Code>{JSON.stringify(variable, null, 2)}</Code>
+              </CardContent>
+            </Card>
+          </TabsContent>
+        )}
+        {debugMode && (
+          <TabsContent value="stats">
+            <Card className="shadow-xs">
+              <CardHeader>
+                <CardTitle>{variable.label ?? variable.name}</CardTitle>
+                {getSplitVariableDescription(variable, stats) && (
+                  <CardDescription>{getSplitVariableDescription(variable, stats)}</CardDescription>
+                )}
+              </CardHeader>
+              <CardContent>
+                <Code>{JSON.stringify(stats, null, 2)}</Code>
+              </CardContent>
+            </Card>
+          </TabsContent>
+        )}
       </Tabs>
     </div>
   );

--- a/apps/web/src/components/debug-toggle.tsx
+++ b/apps/web/src/components/debug-toggle.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { Bug, BugOff } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useAppContext } from "@/context/app-context";
+import { useIsAdmin } from "@/hooks/use-is-admin";
+import { cn } from "@/lib/utils";
+
+type DebugToggleProps = {
+  className?: string;
+};
+
+export function DebugToggle({ className }: DebugToggleProps) {
+  const isAdmin = useIsAdmin();
+  const { debugMode, setDebugMode } = useAppContext();
+
+  if (!isAdmin) {
+    return null;
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={() => setDebugMode(!debugMode)}
+      className={cn("h-8 w-8", className)}
+      title={debugMode ? "Disable debug mode" : "Enable debug mode"}
+    >
+      {debugMode ? (
+        <BugOff className="h-4 w-4" />
+      ) : (
+        <Bug className="h-4 w-4" />
+      )}
+      <span className="sr-only">
+        {debugMode ? "Disable debug mode" : "Enable debug mode"}
+      </span>
+    </Button>
+  );
+}

--- a/apps/web/src/components/project-site-header.tsx
+++ b/apps/web/src/components/project-site-header.tsx
@@ -3,6 +3,7 @@
 import { Separator } from "@/components/ui/separator";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 import { useAppContext } from "@/context/app-context";
+import { DebugToggle } from "./debug-toggle";
 import { ThemeToggle } from "./theme-toggle";
 
 export function ProjectSiteHeader() {
@@ -13,7 +14,10 @@ export function ProjectSiteHeader() {
         <SidebarTrigger className="-ml-1" />
         <Separator orientation="vertical" className="mx-2 data-[orientation=vertical]:h-4" />
         <h1 className="text-lg font-semibold">{activeProject?.name}</h1>
-        <ThemeToggle className="ml-auto" />
+        <div className="flex items-center gap-1 ml-auto">
+          <DebugToggle />
+          <ThemeToggle />
+        </div>
       </div>
     </header>
   );

--- a/apps/web/src/components/site-header.tsx
+++ b/apps/web/src/components/site-header.tsx
@@ -2,6 +2,7 @@
 
 import { Separator } from "@/components/ui/separator";
 import { SidebarTrigger } from "@/components/ui/sidebar";
+import { DebugToggle } from "./debug-toggle";
 import { ImpersonationBanner } from "./impersonation-banner";
 import { ThemeToggle } from "./theme-toggle";
 
@@ -18,7 +19,10 @@ export function SiteHeader({ title }: SiteHeaderProps) {
           <SidebarTrigger className="-ml-1" />
           <Separator orientation="vertical" className="mx-2 data-[orientation=vertical]:h-4" />
           <h1 className="text-lg font-semibold">{title}</h1>
-          <ThemeToggle className="ml-auto" />
+          <div className="flex items-center gap-1 ml-auto">
+            <DebugToggle />
+            <ThemeToggle />
+          </div>
         </div>
       </header>
     </>

--- a/apps/web/src/context/app-context.tsx
+++ b/apps/web/src/context/app-context.tsx
@@ -4,6 +4,7 @@ import { type Organization } from "better-auth/plugins";
 import { ReactNode, createContext, useContext, useEffect, useState } from "react";
 import { useActiveProject } from "@/hooks/use-active-project";
 import { useActiveOrganization } from "@/lib/auth-client";
+import { useDebugMode } from "@/hooks/use-debug-mode";
 
 export type Project = {
   id: string;
@@ -15,8 +16,10 @@ export type Project = {
 type AppContextType = {
   activeOrganization: Organization | null;
   activeProject: Project | null;
+  debugMode: boolean;
   setActiveOrganization: (org: Organization | null) => void;
   setActiveProject: (project: Project | null) => void;
+  setDebugMode: (enabled: boolean) => void;
 };
 
 const AppContext = createContext<AppContextType | undefined>(undefined);
@@ -26,6 +29,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
   const [activeProject, setActiveProject] = useState<Project | null>(null);
   const { data: activeOrganizationSession } = useActiveOrganization();
   const { activeProject: activeProjectDetected } = useActiveProject(activeOrganization);
+  const { debugMode, setDebugMode } = useDebugMode();
 
   useEffect(() => {
     async function detectContext() {
@@ -55,8 +59,10 @@ export function AppProvider({ children }: { children: ReactNode }) {
       value={{
         activeOrganization,
         activeProject,
+        debugMode,
         setActiveOrganization,
         setActiveProject,
+        setDebugMode,
       }}>
       {children}
     </AppContext.Provider>

--- a/apps/web/src/hooks/use-debug-mode.ts
+++ b/apps/web/src/hooks/use-debug-mode.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+const DEBUG_MODE_STORAGE_KEY = "adhoc-debug-mode";
+
+export function useDebugMode() {
+  const [debugMode, setDebugModeState] = useState<boolean>(false);
+
+  // Load debug mode from localStorage on mount
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(DEBUG_MODE_STORAGE_KEY);
+      if (stored !== null) {
+        setDebugModeState(stored === "true");
+      }
+    } catch (error) {
+      console.warn("Failed to load debug mode from localStorage:", error);
+    }
+  }, []);
+
+  // Set debug mode and persist to localStorage
+  const setDebugMode = useCallback((enabled: boolean) => {
+    setDebugModeState(enabled);
+    try {
+      localStorage.setItem(DEBUG_MODE_STORAGE_KEY, enabled.toString());
+    } catch (error) {
+      console.warn("Failed to save debug mode to localStorage:", error);
+    }
+  }, []);
+
+  return {
+    debugMode,
+    setDebugMode,
+  };
+}


### PR DESCRIPTION
## Summary

- Add admin-only debug mode toggle next to theme switcher in page headers
- Provide cleaner default chart interface by hiding all tabs when debug mode is disabled
- Maintain full debugging capabilities for administrators with persistent localStorage state