### PR TITLE
Move theme selector to variable selector card footer for improved space utilization

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -968,7 +968,8 @@
     "label": "Design",
     "labelSelect": "Design:",
     "organizationThemes": "Organisationsthemes",
-    "placeholder": "Design auswählen"
+    "placeholder": "Design auswählen",
+    "changeTheme": "Design ändern"
   },
   "themeToggle": {
     "dark": "Dunkel",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -968,7 +968,8 @@
     "label": "Theme",
     "labelSelect": "Theme:",
     "organizationThemes": "Organization Themes",
-    "placeholder": "Select a theme"
+    "placeholder": "Select a theme",
+    "changeTheme": "Change theme"
   },
   "themeToggle": {
     "dark": "Dark",

--- a/apps/web/src/components/project/adhoc-analysis.tsx
+++ b/apps/web/src/components/project/adhoc-analysis.tsx
@@ -9,7 +9,6 @@ import { type Project } from "@/types/project";
 import { StatsRequest, StatsResponse } from "@/types/stats";
 import { MultiVariableCharts } from "../chart/multi-variable-charts";
 import BarSkeleton from "../chart/bar-skeleton";
-import { ThemeSelector } from "../theme-selector";
 import { AdHocVariablesetSelector, SelectionItem } from "./adhoc-variableset-selector";
 
 import { useThemeConfig } from "@/components/active-theme";
@@ -108,7 +107,6 @@ export function AdHocAnalysis({ project }: AdHocAnalysisProps) {
   return (
     <div className="theme-container flex gap-4">
       <div className="flex w-64 max-w-64 min-w-64 flex-col gap-4">
-        <ThemeSelector className="w-full" />
         <DatasetSelect
           projectId={project.id}
           defaultValue={selectedDataset || undefined}


### PR DESCRIPTION
## Summary

• Improves adhoc analysis interface by relocating theme selector from sidebar to variable selector card footer as a compact icon
• Enhances space utilization while maintaining easy access to theme switching functionality