### PR TITLE
Enhance split variable UX by moving selector to chart footer

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -913,6 +913,12 @@
     "errors": {
       "fetchStats": "Fehler beim Laden der Statistiken"
     },
+    "splitVariable": {
+      "label": "Teilungsvariable:",
+      "none": "Keine",
+      "placeholder": "Teilungsvariable auswählen...",
+      "tooltip": "Diagramme werden nach Kategorien dieser Variable aufgeteilt."
+    },
     "tabs": {
       "chart": "Diagramm",
       "stats": "Statistiken",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -913,6 +913,12 @@
     "errors": {
       "fetchStats": "Error loading dataset statistics"
     },
+    "splitVariable": {
+      "label": "Split Variable:",
+      "none": "None",
+      "placeholder": "Choose split variable...",
+      "tooltip": "Charts will be split by categories of this variable."
+    },
     "tabs": {
       "chart": "Chart",
       "stats": "Statistics",

--- a/apps/web/src/components/chart/adhoc-chart.tsx
+++ b/apps/web/src/components/chart/adhoc-chart.tsx
@@ -47,14 +47,17 @@ import { HorizontalStackedBarAdhoc } from "./horizontal-stacked-bar-adhoc";
 import { MeanBarAdhoc } from "./mean-bar-adhoc";
 import { MetricsCards } from "./metrics-cards";
 import { useAppContext } from "@/context/app-context";
+import { SplitVariableSelector } from "../project/split-variable-selector";
 
 type AdhocChartProps = {
   variable: DatasetVariable;
   stats: StatsResponse;
   datasetId?: string;
+  selectedSplitVariable?: string | null;
+  onSplitVariableChangeAction?: (splitVariable: string | null) => void;
 } & React.HTMLAttributes<HTMLDivElement>;
 
-export function AdhocChart({ variable, stats, datasetId, ...props }: AdhocChartProps) {
+export function AdhocChart({ variable, stats, datasetId, selectedSplitVariable, onSplitVariableChangeAction, ...props }: AdhocChartProps) {
   const t = useTranslations("projectAdhocAnalysis");
   const tChart = useTranslations("chartMetricsCard");
   const { ref, exportPNG } = useChartExport();
@@ -374,7 +377,15 @@ export function AdhocChart({ variable, stats, datasetId, ...props }: AdhocChartP
                 )}
               </CardContent>
               {selectedChartType === "meanBar" && (
-                <CardFooter>
+                <CardFooter className="flex justify-between items-center border-t">
+                  {datasetId && onSplitVariableChangeAction && (
+                    <SplitVariableSelector
+                      datasetId={datasetId}
+                      selectedSplitVariable={selectedSplitVariable || null}
+                      onSplitVariableChangeAction={onSplitVariableChangeAction}
+                      compact
+                    />
+                  )}
                   <Button className="cursor-pointer" variant="outline" onClick={exportPNG}>
                     <DownloadIcon className="h-4 w-4" />
                   </Button>
@@ -451,7 +462,15 @@ export function AdhocChart({ variable, stats, datasetId, ...props }: AdhocChartP
               )}
             </CardHeader>
             <CardContent>{renderChart()}</CardContent>
-            <CardFooter>
+            <CardFooter className="flex justify-between items-center border-t">
+              {datasetId && onSplitVariableChangeAction && (
+                <SplitVariableSelector
+                  datasetId={datasetId}
+                  selectedSplitVariable={selectedSplitVariable || null}
+                  onSplitVariableChangeAction={onSplitVariableChangeAction}
+                  compact
+                />
+              )}
               <Button className="cursor-pointer" variant="outline" onClick={exportPNG}>
                 <DownloadIcon className="h-4 w-4" />
               </Button>

--- a/apps/web/src/components/chart/multi-variable-charts.tsx
+++ b/apps/web/src/components/chart/multi-variable-charts.tsx
@@ -5,7 +5,6 @@ import type { DatasetVariable } from "@/types/dataset-variable";
 import type { VariablesetTreeNode } from "@/types/dataset-variableset";
 import type { StatsResponse } from "@/types/stats";
 import { AdhocChart } from "./adhoc-chart";
-import { SplitVariableSelector } from "../project/split-variable-selector";
 
 type MultiVariableChartsProps = {
   variables: DatasetVariable[];
@@ -60,16 +59,16 @@ export function MultiVariableCharts({
             )}
           </div>
         )}
-        <div className="mb-4">
-          <SplitVariableSelector
-            datasetId={datasetId}
-            selectedSplitVariable={splitVariables[variable.name] || null}
-            onSplitVariableChangeAction={(splitVariable) => 
-              handleSplitVariableChange(variable.name, splitVariable)
-            }
-          />
-        </div>
-        <AdhocChart variable={variable} stats={stats} datasetId={datasetId} className="w-[600px]" />
+        <AdhocChart 
+          variable={variable} 
+          stats={stats} 
+          datasetId={datasetId} 
+          className="w-[600px]"
+          selectedSplitVariable={splitVariables[variable.name] || null}
+          onSplitVariableChangeAction={(splitVariable: string | null) => 
+            handleSplitVariableChange(variable.name, splitVariable)
+          }
+        />
       </div>
     );
   }
@@ -87,21 +86,17 @@ export function MultiVariableCharts({
       {variables.map((variable) => {
         const stats = statsData[variable.name]!; // We know it exists due to hasAllStats check
         return (
-          <div key={variable.id} className="flex flex-col gap-2">
-            <SplitVariableSelector
-              datasetId={datasetId}
-              selectedSplitVariable={splitVariables[variable.name] || null}
-              onSplitVariableChangeAction={(splitVariable) => 
-                handleSplitVariableChange(variable.name, splitVariable)
-              }
-            />
-            <AdhocChart
-              variable={variable}
-              stats={stats}
-              datasetId={datasetId}
-              className="w-[600px]"
-            />
-          </div>
+          <AdhocChart
+            key={variable.id}
+            variable={variable}
+            stats={stats}
+            datasetId={datasetId}
+            className="w-[600px]"
+            selectedSplitVariable={splitVariables[variable.name] || null}
+            onSplitVariableChangeAction={(splitVariable: string | null) => 
+              handleSplitVariableChange(variable.name, splitVariable)
+            }
+          />
         );
       })}
     </div>

--- a/apps/web/src/components/project/split-variable-selector.tsx
+++ b/apps/web/src/components/project/split-variable-selector.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { CircleHelpIcon } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -8,6 +10,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useQueryApi } from "@/hooks/use-query-api";
 import type { DatasetVariable } from "@/types/dataset-variable";
 
@@ -15,6 +18,7 @@ type SplitVariableSelectorProps = {
   datasetId: string;
   selectedSplitVariable: string | null;
   onSplitVariableChangeAction: (splitVariable: string | null) => void;
+  compact?: boolean;
 };
 
 interface ApiResponse {
@@ -28,7 +32,10 @@ export function SplitVariableSelector({
   datasetId,
   selectedSplitVariable,
   onSplitVariableChangeAction,
+  compact = false,
 }: SplitVariableSelectorProps) {
+  const t = useTranslations("projectAdhocAnalysis.splitVariable");
+  
   const { data: splitVariablesResponse, isLoading } = useQueryApi<ApiResponse>({
     endpoint: `/api/datasets/${datasetId}/splitvariables`,
     pagination: { pageIndex: 0, pageSize: 100 },
@@ -47,22 +54,39 @@ export function SplitVariableSelector({
     }
   };
 
+  // Get the label for the selected variable (without variable name)
+  const getSelectedLabel = () => {
+    if (!selectedSplitVariable) return t("none");
+    const selectedVar = splitVariables.find(v => v.name === selectedSplitVariable);
+    return selectedVar?.label || selectedSplitVariable;
+  };
+
   return (
-    <div className="space-y-1">
+    <div className={compact ? "flex items-center gap-2" : "space-y-1"}>
       <div className="flex items-center gap-2">
         <Label htmlFor="split-variable-select" className="text-sm font-medium min-w-fit">
-          {"Split Variable:"}
+          {t("label")}
         </Label>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <CircleHelpIcon className="h-4 w-4 text-muted-foreground cursor-help" />
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>{t("tooltip")}</p>
+          </TooltipContent>
+        </Tooltip>
         <Select
           value={selectedSplitVariable || "none"}
           onValueChange={handleValueChange}
         >
-          <SelectTrigger id="split-variable-select" className="h-8 flex-1">
-            <SelectValue placeholder={"Choose split variable..."} />
+          <SelectTrigger id="split-variable-select" className={compact ? "h-8 w-auto min-w-[180px]" : "h-8 flex-1"}>
+            <SelectValue placeholder={t("placeholder")}>
+              {getSelectedLabel()}
+            </SelectValue>
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="none">
-              {"None"}
+              {t("none")}
             </SelectItem>
             {isLoading && (
               <SelectItem value="loading" disabled>
@@ -77,11 +101,6 @@ export function SplitVariableSelector({
           </SelectContent>
         </Select>
       </div>
-      {selectedSplitVariable && (
-        <p className="text-xs text-muted-foreground ml-0">
-          {"Charts will be split by categories of this variable."}
-        </p>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
• Move split variable selector from above charts to card footer for better space utilization and cleaner interface
• Add internationalization support and helpful tooltips to improve user experience and accessibility