### PR TITLE
Add heading and subheading to admin dashboard page

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -103,6 +103,8 @@
     "title": "Konto löschen"
   },
   "adminDashboard": {
+    "title": "Admin Dashboard",
+    "description": "Zugriff auf administrative Tools und Verwaltung der Anwendungseinstellungen.",
     "datasets": {
       "description": "Verwalten Sie Datensätze und deren Konfigurationen.",
       "link": "Datensätze anzeigen",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -103,6 +103,8 @@
     "title": "Delete Account"
   },
   "adminDashboard": {
+    "title": "Admin Dashboard",
+    "description": "Access administrative tools and manage system settings.",
     "datasets": {
       "description": "Manage datasets and their configurations.",
       "link": "View Datasets",

--- a/apps/web/src/app/(admin)/admin/page.tsx
+++ b/apps/web/src/app/(admin)/admin/page.tsx
@@ -7,7 +7,7 @@ export default async function Page() {
   const t = await getTranslations("adminDashboard");
 
   return (
-    <PageLayout data-testid="admin.page">
+    <PageLayout title={t("title")} description={t("description")} data-testid="admin.page">
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
         <Card className="align-center flex flex-col justify-between shadow-xs">
           <CardHeader>


### PR DESCRIPTION
## Summary
• Add title and description props to PageLayout component on admin dashboard landing page
• Include translations for both English and German locales
• Follow consistent pattern used in other admin pages like organizations and users