### PR TITLE
Update Docker Publish Workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -96,6 +96,7 @@ jobs:
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
---
## Summary
- Enabled multi-platform builds for Docker images by specifying `platforms: linux/amd64,linux/arm64` in the GitHub Actions workflow.
- Improved build consistency and reduced potential issues when deploying on different hardware architectures.
---