### PR TITLE
Add method to round statistical values

### DIFF
--- a/apps/analysis/analysis/tests/web/test_routes.py
+++ b/apps/analysis/analysis/tests/web/test_routes.py
@@ -145,3 +145,34 @@ def test_split_variable_precedence():
     var = request.variables[0]
     actual_split = var.split_variable or request.split_variable
     assert actual_split == "global_split"
+
+
+def test_stats_request_model_with_decimal_places():
+    """Test that the StatsRequest model accepts decimal_places parameter."""
+    from analysis.web.api.datasets.routes import StatsRequest, StatsVariable
+    
+    # Test with decimal_places
+    request = StatsRequest(
+        variables=[
+            StatsVariable(variable="test_var")
+        ],
+        decimal_places=2
+    )
+    assert request.decimal_places == 2
+    
+    # Test without decimal_places (should be 2 by default)
+    request = StatsRequest(
+        variables=[
+            StatsVariable(variable="test_var")
+        ]
+    )
+    assert request.decimal_places == 2
+    
+    # Test with zero decimal places
+    request = StatsRequest(
+        variables=[
+            StatsVariable(variable="test_var")
+        ],
+        decimal_places=0
+    )
+    assert request.decimal_places == 0

--- a/apps/analysis/analysis/web/api/datasets/routes.py
+++ b/apps/analysis/analysis/web/api/datasets/routes.py
@@ -29,6 +29,8 @@ class StatsRequest(BaseModel):
     variables: List[StatsVariable]
     # Keep global split_variable for backward compatibility
     split_variable: Optional[str] = None
+    # Number of decimal places for numeric statistics (mean, std, percentages, etc.)
+    decimal_places: Optional[int] = 2
 
 
 async def _get_dataset_by_id(db: AsyncSession, dataset_id: str) -> Optional[Dataset]:
@@ -265,6 +267,7 @@ async def get_dataset_stats(
                     split_variable=split_var,
                     split_variable_value_labels=split_variable_value_labels,
                     split_variable_missing_values=split_variable_missing_values,
+                    decimal_places=stats_request.decimal_places,
                 )
                 results.append({"variable": var_request.variable, "stats": stats})
             except ValueError as e:

--- a/apps/web/src/components/project/adhoc-analysis.tsx
+++ b/apps/web/src/components/project/adhoc-analysis.tsx
@@ -57,6 +57,7 @@ export function AdHocAnalysis({ project }: AdHocAnalysisProps) {
         // Individual split variable requests will be handled by MultiVariableCharts
         const request: StatsRequest = {
           variables: variables.map(v => ({ variable: v.name })),
+          decimal_places: 2,
         };
 
         mutate(request, {
@@ -84,6 +85,7 @@ export function AdHocAnalysis({ project }: AdHocAnalysisProps) {
     if (currentSelection) {
       const request: StatsRequest = {
         variables: [{ variable: variableName, split_variable: splitVariable }],
+        decimal_places: 2,
       };
 
       mutate(request, {

--- a/apps/web/src/types/stats.ts
+++ b/apps/web/src/types/stats.ts
@@ -10,6 +10,8 @@ export const StatsRequestSchema = z.object({
   variables: z.array(StatsVariableSchema),
   // Keep global split_variable for backward compatibility
   split_variable: z.string().optional(),
+  // Number of decimal places for numeric statistics (mean, std, percentages, etc.)
+  decimal_places: z.number().optional(),
 });
 
 // Schema for the response


### PR DESCRIPTION
---
## Summary
- Added a utility method `_round_if_needed` in `StatisticsService` to round numeric values to specified decimal places if provided.
- Updated the `describe_var` method to include an optional parameter `decimal_places` which controls rounding for numeric statistics. Default is set to 2 decimal places.
- Improved documentation and formatting within `stats.py`.
---