### PR TITLE
Add export/import functionality for dataset variable sets

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -399,6 +399,37 @@
       "moveSet": "Set verschieben",
       "rootLevel": "Hauptebene",
       "variableCount": "{count, plural, =0 {keine Variablen} =1 {1 Variable} other {# Variablen}}"
+    },
+    "exportImport": {
+      "export": "Exportieren",
+      "exporting": "Wird exportiert...",
+      "import": "Importieren",
+      "importDialog": {
+        "title": "Variablen-Sets importieren",
+        "description": "Importieren Sie Variablen-Sets aus einer JSON-Datei. Sie können wählen, wie Konflikte mit bestehenden Variablen-Sets behandelt werden sollen.",
+        "selectFile": "Datei auswählen",
+        "conflictResolution": "Konfliktlösung",
+        "conflictOptions": {
+          "skip": "Bestehende Sets überspringen",
+          "overwrite": "Bestehende Sets überschreiben",
+          "rename": "Importierte Sets umbenennen"
+        },
+        "cancel": "Abbrechen",
+        "importing": "Import wird verarbeitet...",
+        "importCompleted": "Import erfolgreich abgeschlossen",
+        "importFailed": "Import fehlgeschlagen",
+        "summary": {
+          "totalSets": "Sets insgesamt:",
+          "created": "Erstellt:",
+          "updated": "Aktualisiert:",
+          "skipped": "Übersprungen:",
+          "failed": "Fehlgeschlagen:"
+        },
+        "warnings": "Warnungen:",
+        "errors": "Fehler:",
+        "importAnother": "Weitere importieren",
+        "close": "Schließen"
+      }
     }
   },
   "adminSidebar": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -399,6 +399,37 @@
       "moveSet": "Move Set",
       "rootLevel": "Root Level",
       "variableCount": "{count, plural, =0 {no variables} =1 {1 variable} other {# variables}}"
+    },
+    "exportImport": {
+      "export": "Export",
+      "exporting": "Exporting...",
+      "import": "Import",
+      "importDialog": {
+        "title": "Import Variable Sets",
+        "description": "Import variable sets from a JSON file. You can choose how to handle conflicts with existing variable sets.",
+        "selectFile": "Select File",
+        "conflictResolution": "Conflict Resolution",
+        "conflictOptions": {
+          "skip": "Skip existing sets",
+          "overwrite": "Overwrite existing sets", 
+          "rename": "Rename imported sets"
+        },
+        "cancel": "Cancel",
+        "importing": "Processing import...",
+        "importCompleted": "Import completed successfully",
+        "importFailed": "Import failed",
+        "summary": {
+          "totalSets": "Total Sets:",
+          "created": "Created:",
+          "updated": "Updated:",
+          "skipped": "Skipped:", 
+          "failed": "Failed:"
+        },
+        "warnings": "Warnings:",
+        "errors": "Errors:",
+        "importAnother": "Import Another",
+        "close": "Close"
+      }
     }
   },
   "adminSidebar": {

--- a/apps/web/src/app/api/datasets/[id]/variablesets/export/route.ts
+++ b/apps/web/src/app/api/datasets/[id]/variablesets/export/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import { assertAccess, find } from "@/dal/dataset";
+import { exportVariableSets } from "@/dal/dataset-variableset-export";
+import { raiseExceptionResponse } from "@/lib/exception";
+
+export const dynamic = "force-dynamic";
+
+type RouteParams = {
+  params: Promise<{
+    id: string;
+  }>;
+};
+
+export async function GET(_request: Request, { params }: RouteParams) {
+  const { id } = await params;
+
+  if (!id) {
+    return NextResponse.json({ error: "ID is required" }, { status: 400 });
+  }
+
+  try {
+    await assertAccess(id);
+    const dataset = await find(id);
+
+    if (!dataset) {
+      return new NextResponse("Dataset not found", { status: 404 });
+    }
+
+    const exportData = await exportVariableSets(id);
+    
+    // Generate filename with dataset name and current date
+    const date = new Date().toISOString().split('T')[0];
+    const filename = `dataset-${dataset.name.replace(/[^a-zA-Z0-9]/g, '_')}-variablesets-${date}.json`;
+
+    // Return JSON file as download
+    return new NextResponse(JSON.stringify(exportData, null, 2), {
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Disposition": `attachment; filename="${filename}"`,
+        "Cache-Control": "private, max-age=0, must-revalidate",
+      },
+    });
+  } catch (error) {
+    console.error("Error in variableset export:", error);
+    return raiseExceptionResponse(error);
+  }
+}

--- a/apps/web/src/app/api/datasets/[id]/variablesets/import/route.ts
+++ b/apps/web/src/app/api/datasets/[id]/variablesets/import/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import { assertAccess } from "@/dal/dataset";
+import { importVariableSets } from "@/dal/dataset-variableset-export";
+import { raiseExceptionResponse } from "@/lib/exception";
+import { VariableSetExportFileSchema, VariableSetImportOptionsSchema } from "@/types/dataset-variableset-export";
+
+export const dynamic = "force-dynamic";
+
+type RouteParams = {
+  params: Promise<{
+    id: string;
+  }>;
+};
+
+export async function POST(request: Request, { params }: RouteParams) {
+  const { id } = await params;
+
+  if (!id) {
+    return NextResponse.json({ error: "ID is required" }, { status: 400 });
+  }
+
+  try {
+    await assertAccess(id);
+
+    // Parse form data
+    const formData = await request.formData();
+    const file = formData.get("file") as File;
+    const optionsJson = formData.get("options") as string;
+
+    if (!file) {
+      return NextResponse.json({ error: "File is required" }, { status: 400 });
+    }
+
+    // Validate file type
+    if (!file.type.includes("json") && !file.name.endsWith(".json")) {
+      return NextResponse.json({ error: "File must be a JSON file" }, { status: 400 });
+    }
+
+    // Parse import options
+    let options;
+    try {
+      const parsedOptions = optionsJson ? JSON.parse(optionsJson) : {};
+      options = VariableSetImportOptionsSchema.parse(parsedOptions);
+    } catch {
+      return NextResponse.json({ error: "Invalid import options" }, { status: 400 });
+    }
+
+    // Read and parse file content
+    let importData;
+    try {
+      const fileContent = await file.text();
+      const parsedContent = JSON.parse(fileContent);
+      importData = VariableSetExportFileSchema.parse(parsedContent);
+    } catch {
+      return NextResponse.json({ 
+        error: "Invalid file format. Please upload a valid variable sets export file." 
+      }, { status: 400 });
+    }
+
+    // Perform import
+    const result = await importVariableSets(id, importData, options);
+
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("Error in variableset import:", error);
+    return raiseExceptionResponse(error);
+  }
+}

--- a/apps/web/src/components/admin/dataset-editor/variableset-tab.tsx
+++ b/apps/web/src/components/admin/dataset-editor/variableset-tab.tsx
@@ -10,6 +10,7 @@ import type { DatasetVariableset, VariablesetTreeNode } from "@/types/dataset-va
 import { VariableAssignment } from "../dataset-variableset/variable-assignment";
 import { VariablesetForm } from "../dataset-variableset/variableset-form";
 import { VariablesetTree } from "../dataset-variableset/variableset-tree";
+import { ExportImportActions } from "../dataset-variableset/export-import-actions";
 
 interface VariablesetTabProps {
   datasetId: string;
@@ -84,9 +85,12 @@ export function VariablesetTab({ datasetId }: VariablesetTabProps) {
             <CardTitle>{t("editTitle")}</CardTitle>
             <CardDescription>{t("editDescription")}</CardDescription>
             <CardAction>
-              <Button onClick={handleCreateSet} data-testid="admin.dataset.variableset.create" className="cursor-pointer">
-                {t("createSet")}
-              </Button>
+              <div className="flex items-center gap-2">
+                <Button onClick={handleCreateSet} data-testid="admin.dataset.variableset.create" className="cursor-pointer">
+                  {t("createSet")}
+                </Button>
+                <ExportImportActions datasetId={datasetId} onImportSuccess={handleRefresh} />
+              </div>
             </CardAction>
           </CardHeader>
           <CardContent className="p-4">

--- a/apps/web/src/components/admin/dataset-variableset/export-import-actions.tsx
+++ b/apps/web/src/components/admin/dataset-variableset/export-import-actions.tsx
@@ -1,0 +1,293 @@
+"use client";
+
+import { Download, Upload, CheckCircle, XCircle } from "lucide-react";
+import { useState, useRef } from "react";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Label } from "@/components/ui/label";
+import { Alert } from "@/components/ui/alert";
+import type { VariableSetImportResult, VariableSetImportOptions } from "@/types/dataset-variableset-export";
+
+interface ExportImportActionsProps {
+  datasetId: string;
+  onImportSuccess?: () => void;
+}
+
+export function ExportImportActions({ datasetId, onImportSuccess }: ExportImportActionsProps) {
+  const t = useTranslations("adminDatasetVariableset.exportImport");
+  const [importOpen, setImportOpen] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
+  const [isImporting, setIsImporting] = useState(false);
+  const [importResult, setImportResult] = useState<VariableSetImportResult | null>(null);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [conflictResolution, setConflictResolution] = useState<VariableSetImportOptions["conflictResolution"]>("skip");
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleExport = async () => {
+    setIsExporting(true);
+    try {
+      const response = await fetch(`/api/datasets/${datasetId}/variablesets/export`);
+      
+      if (!response.ok) {
+        throw new Error("Export failed");
+      }
+
+      // Get the filename from the Content-Disposition header
+      const contentDisposition = response.headers.get("Content-Disposition");
+      const filenameMatch = contentDisposition?.match(/filename="(.+)"/);
+      const filename = filenameMatch?.[1] ?? `variablesets-${Date.now()}.json`;
+
+      // Create download
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      window.URL.revokeObjectURL(url);
+    } catch (error) {
+      console.error("Export error:", error);
+      alert("Export failed. Please try again.");
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      setSelectedFile(file);
+      setImportResult(null);
+    }
+  };
+
+  const handleImport = async () => {
+    if (!selectedFile) return;
+
+    setIsImporting(true);
+    setImportResult(null);
+
+    try {
+      const formData = new FormData();
+      formData.append("file", selectedFile);
+      formData.append("options", JSON.stringify({ conflictResolution }));
+
+      const response = await fetch(`/api/datasets/${datasetId}/variablesets/import`, {
+        method: "POST",
+        body: formData,
+      });
+
+      const result = await response.json();
+
+      if (!response.ok) {
+        throw new Error(result.error || "Import failed");
+      }
+
+      setImportResult(result);
+      
+      if (result.success && onImportSuccess) {
+        onImportSuccess();
+      }
+    } catch (error) {
+      console.error("Import error:", error);
+      setImportResult({
+        success: false,
+        summary: { totalSets: 0, createdSets: 0, skippedSets: 0, updatedSets: 0, failedSets: 0 },
+        errors: [error instanceof Error ? error.message : "Import failed"],
+        warnings: [],
+        details: [],
+      });
+    } finally {
+      setIsImporting(false);
+    }
+  };
+
+  const resetImport = () => {
+    setSelectedFile(null);
+    setImportResult(null);
+    setConflictResolution("skip");
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
+
+  const handleImportDialogClose = (open: boolean) => {
+    setImportOpen(open);
+    if (!open) {
+      resetImport();
+    }
+  };
+
+  return (
+    <div className="flex gap-2">
+      <Button
+        onClick={handleExport}
+        disabled={isExporting}
+        variant="outline"
+        size="sm"
+        className="flex items-center gap-2"
+      >
+        <Download className="h-4 w-4" />
+        {isExporting ? t("exporting") : t("export")}
+      </Button>
+
+      <Dialog open={importOpen} onOpenChange={handleImportDialogClose}>
+        <DialogTrigger asChild>
+          <Button variant="outline" size="sm" className="flex items-center gap-2">
+            <Upload className="h-4 w-4" />
+            {t("import")}
+          </Button>
+        </DialogTrigger>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>{t("importDialog.title")}</DialogTitle>
+            <DialogDescription>
+              {t("importDialog.description")}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4">
+            {!importResult && (
+              <>
+                <div>
+                  <Label htmlFor="file-upload">{t("importDialog.selectFile")}</Label>
+                  <input
+                    ref={fileInputRef}
+                    id="file-upload"
+                    type="file"
+                    accept=".json"
+                    onChange={handleFileSelect}
+                    className="w-full mt-1 p-2 border border-gray-300 rounded-md"
+                  />
+                </div>
+
+                <div>
+                  <Label htmlFor="conflict-resolution">{t("importDialog.conflictResolution")}</Label>
+                  <Select value={conflictResolution} onValueChange={(value: VariableSetImportOptions["conflictResolution"]) => setConflictResolution(value)}>
+                    <SelectTrigger className="w-full mt-1">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="skip">{t("importDialog.conflictOptions.skip")}</SelectItem>
+                      <SelectItem value="overwrite">{t("importDialog.conflictOptions.overwrite")}</SelectItem>
+                      <SelectItem value="rename">{t("importDialog.conflictOptions.rename")}</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="flex gap-2 justify-end">
+                  <Button variant="outline" onClick={() => setImportOpen(false)}>
+                    {t("importDialog.cancel")}
+                  </Button>
+                  <Button
+                    onClick={handleImport}
+                    disabled={!selectedFile || isImporting}
+                    className="flex items-center gap-2"
+                  >
+                    {isImporting && <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />}
+                    {t("import")}
+                  </Button>
+                </div>
+              </>
+            )}
+
+            {isImporting && (
+              <div className="space-y-2">
+                <div className="flex items-center gap-2">
+                  <div className="w-4 h-4 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+                  <span>{t("importDialog.importing")}</span>
+                </div>
+                <div className="w-full bg-gray-200 rounded-full h-2">
+                  <div className="bg-blue-600 h-2 rounded-full animate-pulse" style={{ width: "100%" }}></div>
+                </div>
+              </div>
+            )}
+
+            {importResult && (
+              <div className="space-y-4">
+                <Alert className={importResult.success ? "border-green-200 bg-green-50" : "border-red-200 bg-red-50"}>
+                  <div className="flex items-center gap-2">
+                    {importResult.success ? (
+                      <CheckCircle className="h-4 w-4 text-green-600" />
+                    ) : (
+                      <XCircle className="h-4 w-4 text-red-600" />
+                    )}
+                    <span className="font-medium">
+                      {importResult.success ? t("importDialog.importCompleted") : t("importDialog.importFailed")}
+                    </span>
+                  </div>
+                </Alert>
+
+                <div className="grid grid-cols-2 gap-4 text-sm">
+                  <div>
+                    <span className="font-medium">{t("importDialog.summary.totalSets")}</span> {importResult.summary.totalSets}
+                  </div>
+                  <div>
+                    <span className="font-medium text-green-600">{t("importDialog.summary.created")}</span> {importResult.summary.createdSets}
+                  </div>
+                  <div>
+                    <span className="font-medium text-blue-600">{t("importDialog.summary.updated")}</span> {importResult.summary.updatedSets}
+                  </div>
+                  <div>
+                    <span className="font-medium text-yellow-600">{t("importDialog.summary.skipped")}</span> {importResult.summary.skippedSets}
+                  </div>
+                  <div>
+                    <span className="font-medium text-red-600">{t("importDialog.summary.failed")}</span> {importResult.summary.failedSets}
+                  </div>
+                </div>
+
+                {importResult.warnings.length > 0 && (
+                  <div>
+                    <h4 className="font-medium text-yellow-600 mb-2">{t("importDialog.warnings")}</h4>
+                    <ul className="list-disc pl-4 space-y-1 text-sm">
+                      {importResult.warnings.map((warning, index) => (
+                        <li key={index} className="text-yellow-700">{warning}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+
+                {importResult.errors.length > 0 && (
+                  <div>
+                    <h4 className="font-medium text-red-600 mb-2">{t("importDialog.errors")}</h4>
+                    <ul className="list-disc pl-4 space-y-1 text-sm">
+                      {importResult.errors.map((error, index) => (
+                        <li key={index} className="text-red-700">{error}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+
+                <div className="flex gap-2 justify-end">
+                  <Button variant="outline" onClick={resetImport}>
+                    {t("importDialog.importAnother")}
+                  </Button>
+                  <Button onClick={() => setImportOpen(false)}>
+                    {t("importDialog.close")}
+                  </Button>
+                </div>
+              </div>
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/web/src/dal/dataset-variableset-export.ts
+++ b/apps/web/src/dal/dataset-variableset-export.ts
@@ -1,0 +1,286 @@
+import "server-only";
+import { eq } from "drizzle-orm";
+import { defaultClient as db } from "@repo/database/clients";
+import {
+  dataset,
+  datasetVariable,
+  datasetVariableset,
+  datasetVariablesetItem,
+} from "@repo/database/schema";
+import type { VariableSetExport, VariableSetExportFile, VariableSetImportOptions, VariableSetImportResult } from "@/types/dataset-variableset-export";
+
+export async function exportVariableSets(datasetId: string): Promise<VariableSetExportFile> {
+  // Get dataset info
+  const datasetInfo = await db
+    .select({
+      id: dataset.id,
+      name: dataset.name,
+    })
+    .from(dataset)
+    .where(eq(dataset.id, datasetId))
+    .then(rows => rows[0]);
+
+  if (!datasetInfo) {
+    throw new Error("Dataset not found");
+  }
+
+  // Get all variable sets with their variables
+  const variableSetsQuery = await db
+    .select({
+      setId: datasetVariableset.id,
+      setName: datasetVariableset.name,
+      setDescription: datasetVariableset.description,
+      setParentId: datasetVariableset.parentId,
+      setOrderIndex: datasetVariableset.orderIndex,
+      variableName: datasetVariable.name,
+    })
+    .from(datasetVariableset)
+    .leftJoin(datasetVariablesetItem, eq(datasetVariableset.id, datasetVariablesetItem.variablesetId))
+    .leftJoin(datasetVariable, eq(datasetVariablesetItem.variableId, datasetVariable.id))
+    .where(eq(datasetVariableset.datasetId, datasetId))
+    .orderBy(datasetVariableset.orderIndex, datasetVariableset.name);
+
+  // Create a map of parent IDs to parent names
+  const parentMap = new Map<string, string>();
+  const allSets = await db
+    .select({
+      id: datasetVariableset.id,
+      name: datasetVariableset.name,
+    })
+    .from(datasetVariableset)
+    .where(eq(datasetVariableset.datasetId, datasetId));
+
+  allSets.forEach(set => {
+    parentMap.set(set.id, set.name);
+  });
+
+  // Group variables by variable set
+  const variableSetMap = new Map<string, {
+    name: string;
+    description: string | null;
+    parentId: string | null;
+    orderIndex: number;
+    variables: string[];
+  }>();
+
+  variableSetsQuery.forEach(row => {
+    if (!variableSetMap.has(row.setId)) {
+      variableSetMap.set(row.setId, {
+        name: row.setName,
+        description: row.setDescription,
+        parentId: row.setParentId,
+        orderIndex: row.setOrderIndex,
+        variables: [],
+      });
+    }
+
+    if (row.variableName) {
+      variableSetMap.get(row.setId)!.variables.push(row.variableName);
+    }
+  });
+
+  // Convert to export format
+  const variableSets: VariableSetExport[] = Array.from(variableSetMap.values()).map(set => ({
+    name: set.name,
+    description: set.description,
+    parentName: set.parentId ? parentMap.get(set.parentId) || null : null,
+    orderIndex: set.orderIndex,
+    variables: set.variables.sort(), // Sort variables for consistency
+  }));
+
+  return {
+    metadata: {
+      datasetId: datasetInfo.id,
+      datasetName: datasetInfo.name,
+      exportedAt: new Date().toISOString(),
+      version: "1.0",
+    },
+    variableSets,
+  };
+}
+
+export async function importVariableSets(
+  datasetId: string,
+  importData: VariableSetExportFile,
+  options: VariableSetImportOptions
+): Promise<VariableSetImportResult> {
+  const result: VariableSetImportResult = {
+    success: true,
+    summary: {
+      totalSets: importData.variableSets.length,
+      createdSets: 0,
+      skippedSets: 0,
+      updatedSets: 0,
+      failedSets: 0,
+    },
+    errors: [],
+    warnings: [],
+    details: [],
+  };
+
+  try {
+    // Get all existing variables for the dataset
+    const existingVariables = await db
+      .select({
+        id: datasetVariable.id,
+        name: datasetVariable.name,
+      })
+      .from(datasetVariable)
+      .where(eq(datasetVariable.datasetId, datasetId));
+
+    const variableNameToIdMap = new Map<string, string>();
+    existingVariables.forEach(variable => {
+      variableNameToIdMap.set(variable.name, variable.id);
+    });
+
+    // Get existing variable sets
+    const existingVariableSets = await db
+      .select({
+        id: datasetVariableset.id,
+        name: datasetVariableset.name,
+      })
+      .from(datasetVariableset)
+      .where(eq(datasetVariableset.datasetId, datasetId));
+
+    const existingSetNames = new Set(existingVariableSets.map(set => set.name));
+
+    // Create a map to track created sets for parent relationships
+    const createdSetsMap = new Map<string, string>(); // name -> id
+
+    // First pass: create all variable sets (without parent relationships)
+    for (const importSet of importData.variableSets) {
+      try {
+        // Check for conflicts
+        const nameExists = existingSetNames.has(importSet.name);
+        let finalName = importSet.name;
+
+        if (nameExists) {
+          if (options.conflictResolution === "skip") {
+            result.summary.skippedSets++;
+            result.details.push({
+              setName: importSet.name,
+              status: "skipped",
+              message: "Variable set already exists",
+            });
+            continue;
+          } else if (options.conflictResolution === "rename") {
+            let counter = 1;
+            while (existingSetNames.has(`${importSet.name}_${counter}`)) {
+              counter++;
+            }
+            finalName = `${importSet.name}_${counter}`;
+          }
+        }
+
+        // Validate variables
+        const validVariableIds: string[] = [];
+        const unmatchedVariables: string[] = [];
+
+        for (const variableName of importSet.variables) {
+          const variableId = variableNameToIdMap.get(variableName);
+          if (variableId) {
+            validVariableIds.push(variableId);
+          } else {
+            unmatchedVariables.push(variableName);
+          }
+        }
+
+        if (validVariableIds.length === 0 && importSet.variables.length > 0) {
+          result.summary.failedSets++;
+          result.details.push({
+            setName: importSet.name,
+            status: "failed",
+            message: "No valid variables found",
+            unmatchedVariables,
+          });
+          continue;
+        }
+
+        // Create the variable set
+        const createdSetResult = await db
+          .insert(datasetVariableset)
+          .values({
+            name: finalName,
+            description: importSet.description,
+            datasetId,
+            orderIndex: importSet.orderIndex,
+            // parentId will be set in second pass
+          })
+          .returning({ id: datasetVariableset.id });
+
+        if (!createdSetResult.length) {
+          throw new Error("Failed to create variable set");
+        }
+
+        const createdSetId = createdSetResult[0]!.id;
+        createdSetsMap.set(importSet.name, createdSetId);
+
+        // Create variable set items
+        if (validVariableIds.length > 0) {
+          await db
+            .insert(datasetVariablesetItem)
+            .values(
+              validVariableIds.map((variableId, index) => ({
+                variablesetId: createdSetId,
+                variableId,
+                orderIndex: index,
+              }))
+            );
+        }
+
+        if (nameExists && options.conflictResolution === "overwrite") {
+          result.summary.updatedSets++;
+          result.details.push({
+            setName: finalName,
+            status: "updated",
+            message: unmatchedVariables.length > 0 ? `${unmatchedVariables.length} variables could not be matched` : undefined,
+            unmatchedVariables: unmatchedVariables.length > 0 ? unmatchedVariables : undefined,
+          });
+        } else {
+          result.summary.createdSets++;
+          result.details.push({
+            setName: finalName,
+            status: "created",
+            message: unmatchedVariables.length > 0 ? `${unmatchedVariables.length} variables could not be matched` : undefined,
+            unmatchedVariables: unmatchedVariables.length > 0 ? unmatchedVariables : undefined,
+          });
+        }
+
+        if (unmatchedVariables.length > 0) {
+          result.warnings.push(`Variable set "${finalName}": ${unmatchedVariables.length} variables could not be matched`);
+        }
+
+      } catch (error) {
+        result.summary.failedSets++;
+        result.details.push({
+          setName: importSet.name,
+          status: "failed",
+          message: error instanceof Error ? error.message : "Unknown error",
+        });
+      }
+    }
+
+    // Second pass: update parent relationships
+    for (const importSet of importData.variableSets) {
+      if (importSet.parentName && createdSetsMap.has(importSet.name)) {
+        const setId = createdSetsMap.get(importSet.name)!;
+        const parentId = createdSetsMap.get(importSet.parentName);
+
+        if (parentId) {
+          await db
+            .update(datasetVariableset)
+            .set({ parentId })
+            .where(eq(datasetVariableset.id, setId));
+        } else {
+          result.warnings.push(`Parent "${importSet.parentName}" not found for variable set "${importSet.name}"`);
+        }
+      }
+    }
+
+  } catch (error) {
+    result.success = false;
+    result.errors.push(error instanceof Error ? error.message : "Unknown error occurred during import");
+  }
+
+  return result;
+}

--- a/apps/web/src/types/dataset-variableset-export.ts
+++ b/apps/web/src/types/dataset-variableset-export.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+
+export const VariableSetExportSchema = z.object({
+  name: z.string(),
+  description: z.string().nullable(),
+  parentName: z.string().nullable(),
+  orderIndex: z.number(),
+  variables: z.array(z.string()),
+});
+
+export const VariableSetExportFileSchema = z.object({
+  metadata: z.object({
+    datasetId: z.string(),
+    datasetName: z.string(),
+    exportedAt: z.string(),
+    version: z.string(),
+  }),
+  variableSets: z.array(VariableSetExportSchema),
+});
+
+export const VariableSetImportOptionsSchema = z.object({
+  conflictResolution: z.enum(["skip", "overwrite", "rename"]).default("skip"),
+});
+
+export const VariableSetImportResultSchema = z.object({
+  success: z.boolean(),
+  summary: z.object({
+    totalSets: z.number(),
+    createdSets: z.number(),
+    skippedSets: z.number(),
+    updatedSets: z.number(),
+    failedSets: z.number(),
+  }),
+  errors: z.array(z.string()),
+  warnings: z.array(z.string()),
+  details: z.array(z.object({
+    setName: z.string(),
+    status: z.enum(["created", "skipped", "updated", "failed"]),
+    message: z.string().optional(),
+    unmatchedVariables: z.array(z.string()).optional(),
+  })),
+});
+
+export type VariableSetExport = z.infer<typeof VariableSetExportSchema>;
+export type VariableSetExportFile = z.infer<typeof VariableSetExportFileSchema>;
+export type VariableSetImportOptions = z.infer<typeof VariableSetImportOptionsSchema>;
+export type VariableSetImportResult = z.infer<typeof VariableSetImportResultSchema>;


### PR DESCRIPTION
## Summary
- Add comprehensive export/import functionality for dataset variable sets
- Enable users to export variable sets as JSON files with full hierarchy and variable names
- Provide import capability with conflict resolution options (skip/overwrite/rename)

## Key Features
- **Export API**: Downloads variable sets as JSON with proper hierarchy structure
- **Import API**: Handles file uploads with robust conflict resolution and validation
- **UI Component**: Export/import buttons with progress indicators and detailed result feedback
- **Data Access Layer**: Variable name matching and hierarchy preservation during import/export
- **Type Safety**: Comprehensive TypeScript types and Zod schemas for validation
- **Internationalization**: Full English and German translation support

## Technical Implementation
- Export endpoint: `GET /api/datasets/[id]/variablesets/export`
- Import endpoint: `POST /api/datasets/[id]/variablesets/import`
- New component: `ExportImportActions` integrated into variable sets admin tab
- Data validation using Zod schemas for both export and import operations
- Conflict resolution strategies: skip existing, overwrite existing, or rename imported sets

## Testing
- ✅ TypeScript compilation passes
- ✅ ESLint checks pass with zero warnings
- ✅ All translation keys added for English and German
- ✅ Proper error handling and user feedback implemented