### PR TITLE
refactor(email): use PreviewProps for email template defaults

### DIFF
--- a/packages/email/src/templates/email-change.tsx
+++ b/packages/email/src/templates/email-change.tsx
@@ -14,14 +14,14 @@ import { Footer } from "../components/footer";
 import type { EmailChangeProps } from "../types";
 
 export default function EmailChange({
-  email = "user@example.com",
-  newEmail = "newemail@example.com",
-  url = "http://localhost:3000/auth/verify-email-change?token=change123",
-  heading = "Confirm Your New Email Address",
-  content = "You have requested to change your email address.",
-  action = "Verify Email Change",
-  baseUrl = "http://localhost:3000",
-  siteName = "Next.js App",
+  email,
+  newEmail,
+  url,
+  heading,
+  content,
+  action,
+  baseUrl,
+  siteName,
 }: EmailChangeProps) {
   return (
     <Html>
@@ -63,3 +63,14 @@ export default function EmailChange({
     </Html>
   );
 }
+
+EmailChange.PreviewProps = {
+  email: "user@example.com",
+  newEmail: "newemail@example.com",
+  url: "http://localhost:3000/auth/verify-email-change?token=change123",
+  heading: "Confirm Your New Email Address",
+  content: "You have requested to change your email address.",
+  action: "Verify Email Change",
+  baseUrl: "http://localhost:3000",
+  siteName: "Next.js App",
+} as EmailChangeProps;

--- a/packages/email/src/templates/email-verification.tsx
+++ b/packages/email/src/templates/email-verification.tsx
@@ -14,13 +14,13 @@ import { Footer } from "../components/footer";
 import type { EmailTemplateProps } from "../types";
 
 export default function EmailVerification({
-  email = "user@example.com",
-  url = "http://localhost:3000/auth/verify?token=abc123xyz",
-  heading = "Email Verification",
-  content = "In order to be able to log in, you need to verify your email address.",
-  action = "Verify Email",
-  baseUrl = "http://localhost:3000",
-  siteName = "Next.js App",
+  email,
+  url,
+  heading,
+  content,
+  action,
+  baseUrl,
+  siteName,
 }: EmailTemplateProps) {
   return (
     <Html>
@@ -54,3 +54,13 @@ export default function EmailVerification({
     </Html>
   );
 }
+
+EmailVerification.PreviewProps = {
+  email: "user@example.com",
+  url: "http://localhost:3000/auth/verify?token=abc123xyz",
+  heading: "Email Verification",
+  content: "In order to be able to log in, you need to verify your email address.",
+  action: "Verify Email",
+  baseUrl: "http://localhost:3000",
+  siteName: "Next.js App",
+} as EmailTemplateProps;

--- a/packages/email/src/templates/organization-invite.tsx
+++ b/packages/email/src/templates/organization-invite.tsx
@@ -14,16 +14,16 @@ import { Footer } from "../components/footer";
 import type { OrganizationInviteProps } from "../types";
 
 export default function OrganizationInvite({
-  email = "user@example.com",
-  url = "http://localhost:3000/auth/accept-invitation/inv_12345",
-  organizationName = "Acme Corporation",
-  inviterName = "John Doe",
-  inviterEmail = "john@example.com",
-  heading = "You Have Been Invited",
-  content = "You have been invited to join an organization.",
-  action = "Accept Invitation",
-  baseUrl = "http://localhost:3000",
-  siteName = "Next.js App",
+  email,
+  url,
+  organizationName,
+  inviterName,
+  inviterEmail,
+  heading,
+  content,
+  action,
+  baseUrl,
+  siteName,
 }: OrganizationInviteProps) {
   return (
     <Html>
@@ -72,3 +72,16 @@ export default function OrganizationInvite({
     </Html>
   );
 }
+
+OrganizationInvite.PreviewProps = {
+  email: "user@example.com",
+  url: "http://localhost:3000/auth/accept-invitation/inv_12345",
+  organizationName: "Acme Corporation",
+  inviterName: "John Doe",
+  inviterEmail: "john@example.com",
+  heading: "You Have Been Invited",
+  content: "You have been invited to join an organization.",
+  action: "Accept Invitation",
+  baseUrl: "http://localhost:3000",
+  siteName: "Next.js App",
+} as OrganizationInviteProps;

--- a/packages/email/src/templates/password-reset.tsx
+++ b/packages/email/src/templates/password-reset.tsx
@@ -14,13 +14,13 @@ import { Footer } from "../components/footer";
 import type { EmailTemplateProps } from "../types";
 
 export default function PasswordReset({
-  email = "user@example.com",
-  url = "http://localhost:3000/auth/reset-password?token=xyz789abc",
-  heading = "Reset Your Password",
-  content = "You are receiving this email because we received a password reset request for your account.",
-  action = "Reset Password",
-  baseUrl = "http://localhost:3000",
-  siteName = "Next.js App",
+  email,
+  url,
+  heading,
+  content,
+  action,
+  baseUrl,
+  siteName,
 }: EmailTemplateProps) {
   return (
     <Html>
@@ -57,3 +57,13 @@ export default function PasswordReset({
     </Html>
   );
 }
+
+PasswordReset.PreviewProps = {
+  email: "user@example.com",
+  url: "http://localhost:3000/auth/reset-password?token=xyz789abc",
+  heading: "Reset Your Password",
+  content: "You are receiving this email because we received a password reset request for your account.",
+  action: "Reset Password",
+  baseUrl: "http://localhost:3000",
+  siteName: "Next.js App",
+} as EmailTemplateProps;


### PR DESCRIPTION
## Summary
- Refactored email templates to use `PreviewProps` pattern for preview data instead of inline default parameters, improving react-email CLI preview experience