### PR TITLE
Fix email template translations and URL display

### DIFF
--- a/packages/email/src/templates/email-change.tsx
+++ b/packages/email/src/templates/email-change.tsx
@@ -58,7 +58,7 @@ export default function EmailChange({
               {t.urlInstructions}
             </Text>
             <Text className="max-w-sm flex-wrap break-words font-medium text-purple-600 no-underline">
-              {url.replace(/^https?:\/\//, "")}
+              {url}
             </Text>
             <Footer email={email} baseUrl={baseUrl} siteName={siteName} locale={locale} />
           </Container>
@@ -72,9 +72,9 @@ EmailChange.PreviewProps = {
   email: "user@example.com",
   newEmail: "newemail@example.com",
   url: "http://localhost:3000/auth/verify-email-change?token=change123",
-  heading: "Confirm Your New Email Address",
-  content: "You have requested to change your email address.",
-  action: "Verify Email Change",
+  heading: getEmailTranslations("emailChange", "en", { newEmail: "newemail@example.com" }).heading,
+  content: getEmailTranslations("emailChange", "en", { newEmail: "newemail@example.com" }).content,
+  action: getEmailTranslations("emailChange", "en", { newEmail: "newemail@example.com" }).action,
   baseUrl: "http://localhost:3000",
   siteName: "Next.js App",
   locale: "en",

--- a/packages/email/src/templates/email-verification.tsx
+++ b/packages/email/src/templates/email-verification.tsx
@@ -49,7 +49,7 @@ export default function EmailVerification({
               {t.urlInstructions}
             </Text>
             <Text className="max-w-sm flex-wrap break-words font-medium text-purple-600 no-underline">
-              {url.replace(/^https?:\/\//, "")}
+              {url}
             </Text>
             <Footer email={email} baseUrl={baseUrl} siteName={siteName} locale={locale} />
           </Container>
@@ -62,9 +62,9 @@ export default function EmailVerification({
 EmailVerification.PreviewProps = {
   email: "user@example.com",
   url: "http://localhost:3000/auth/verify?token=abc123xyz",
-  heading: "Email Verification",
-  content: "In order to be able to log in, you need to verify your email address.",
-  action: "Verify Email",
+  heading: getEmailTranslations("emailVerification", "en").heading,
+  content: getEmailTranslations("emailVerification", "en").content,
+  action: getEmailTranslations("emailVerification", "en").action,
   baseUrl: "http://localhost:3000",
   siteName: "Next.js App",
   locale: "en",

--- a/packages/email/src/templates/organization-invite.tsx
+++ b/packages/email/src/templates/organization-invite.tsx
@@ -48,7 +48,7 @@ export default function OrganizationInvite({
                 >
                   {inviterEmail}
                 </Link>
-                ) {t.invitedBy} <strong>{organizationName}</strong>!
+                ) {t.invitedBy}
               </Text>
             ) : (
               <Text className="text-sm leading-6 text-black">
@@ -67,7 +67,7 @@ export default function OrganizationInvite({
               {t.urlInstructions}
             </Text>
             <Text className="max-w-sm flex-wrap break-words font-medium text-purple-600 no-underline">
-              {url.replace(/^https?:\/\//, "")}
+              {url}
             </Text>
             <Footer email={email} baseUrl={baseUrl} siteName={siteName} locale={locale} />
           </Container>
@@ -83,9 +83,9 @@ OrganizationInvite.PreviewProps = {
   organizationName: "Acme Corporation",
   inviterName: "John Doe",
   inviterEmail: "john@example.com",
-  heading: "You Have Been Invited",
-  content: "You have been invited to join an organization.",
-  action: "Accept Invitation",
+  heading: getEmailTranslations("organizationInvite", "en", { organizationName: "Acme Corporation" }).heading,
+  content: getEmailTranslations("organizationInvite", "en", { organizationName: "Acme Corporation" }).content,
+  action: getEmailTranslations("organizationInvite", "en", { organizationName: "Acme Corporation" }).action,
   baseUrl: "http://localhost:3000",
   siteName: "Next.js App",
   locale: "en",

--- a/packages/email/src/templates/password-reset.tsx
+++ b/packages/email/src/templates/password-reset.tsx
@@ -52,7 +52,7 @@ export default function PasswordReset({
               {t.urlInstructions}
             </Text>
             <Text className="max-w-sm flex-wrap break-words font-medium text-purple-600 no-underline">
-              {url.replace(/^https?:\/\//, "")}
+              {url}
             </Text>
             <Footer email={email} baseUrl={baseUrl} siteName={siteName} locale={locale} />
           </Container>
@@ -65,9 +65,9 @@ export default function PasswordReset({
 PasswordReset.PreviewProps = {
   email: "user@example.com",
   url: "http://localhost:3000/auth/reset-password?token=xyz789abc",
-  heading: "Reset Your Password",
-  content: "You are receiving this email because we received a password reset request for your account.",
-  action: "Reset Password",
+  heading: getEmailTranslations("passwordReset", "en").heading,
+  content: getEmailTranslations("passwordReset", "en").content,
+  action: getEmailTranslations("passwordReset", "en").action,
   baseUrl: "http://localhost:3000",
   siteName: "Next.js App",
   locale: "en",

--- a/packages/email/src/translations.ts
+++ b/packages/email/src/translations.ts
@@ -18,8 +18,7 @@ const emailTranslations = {
     emailChange: {
       subject: "Confirm your new email address",
       heading: "Confirm your new email address",
-      content: (newEmail: string) =>
-        `You have requested to change your email to ${newEmail}. Please verify this change by clicking the link below.`,
+      content: "You have requested to change your email address.",
       action: "Verify Email Change",
       newEmailLabel: "Your new email address will be:",
       confirmInstructions: "Please confirm this change by clicking the button below.",
@@ -31,7 +30,7 @@ const emailTranslations = {
       content: (organizationName: string) => `You have been invited to join an organization.`,
       action: "Accept invitation",
       invitedBy: (inviterName: string, organizationName: string) =>
-        `has invited you to join`,
+        `has invited you to join ${organizationName}.`,
       joinPrompt: (organizationName: string) => `Join ${organizationName} to get started.`,
       urlInstructions: "or copy and paste this URL into your browser:",
     },
@@ -61,8 +60,7 @@ const emailTranslations = {
     emailChange: {
       subject: "Bestätigen Sie Ihre neue E-Mail-Adresse",
       heading: "Bestätigen Sie Ihre neue E-Mail-Adresse",
-      content: (newEmail: string) =>
-        `Sie haben beantragt, Ihre E-Mail-Adresse auf ${newEmail} zu ändern. Bitte bestätigen Sie diese Änderung, indem Sie auf den untenstehenden Link klicken.`,
+      content: "Sie haben beantragt, Ihre E-Mail-Adresse zu ändern.",
       action: "E-Mail-Änderung bestätigen",
       newEmailLabel: "Ihre neue E-Mail-Adresse wird sein:",
       confirmInstructions: "Bitte bestätigen Sie diese Änderung, indem Sie auf die Schaltfläche unten klicken.",
@@ -74,7 +72,7 @@ const emailTranslations = {
       content: (organizationName: string) => `Sie wurden eingeladen, einer Organisation beizutreten.`,
       action: "Einladung annehmen",
       invitedBy: (inviterName: string, organizationName: string) =>
-        `hat Sie eingeladen, beizutreten`,
+        `hat Sie eingeladen, der Organisation ${organizationName} beizutreten.`,
       joinPrompt: (organizationName: string) => `Treten Sie ${organizationName} bei, um loszulegen.`,
       urlInstructions: "oder kopieren Sie diese URL und fügen Sie sie in Ihren Browser ein:",
     },


### PR DESCRIPTION
## Summary

- Fixed email heading capitalization to use proper case instead of title case
- Updated all email templates to display full URLs (including protocol) for easier copy-paste
- Refactored PreviewProps to use centralized translations instead of hardcoded strings
- Simplified email change content by removing redundant confirmation instructions
- Fixed German organization invite translation word order
- Removed duplicate organization name display in invitation emails