### PR TITLE
fix(i18n): replace hardcoded split variable text with translations

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -946,6 +946,7 @@
     "errors": {
       "fetchStats": "Fehler beim Laden der Statistiken"
     },
+    "splitBy": "aufgeteilt nach: {variable}",
     "splitVariable": {
       "label": "Teilungsvariable:",
       "none": "Keine",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -946,6 +946,7 @@
     "errors": {
       "fetchStats": "Error loading dataset statistics"
     },
+    "splitBy": "Split by {variable}",
     "splitVariable": {
       "label": "Split Variable:",
       "none": "None",

--- a/apps/web/src/components/chart/adhoc-chart.tsx
+++ b/apps/web/src/components/chart/adhoc-chart.tsx
@@ -92,12 +92,12 @@ export function AdhocChart({ variable, stats, datasetId, selectedSplitVariable, 
       const splitVariable = allVariables.find((v: DatasetVariable) => v.name === splitVariableName);
       if (splitVariable) {
         const splitVariableLabel = splitVariable.label ?? splitVariable.name;
-        return `Split by ${splitVariableLabel}`;
+        return t("splitBy", { variable: splitVariableLabel });
       }
     }
 
     // Fallback to variable name if no label found
-    return `Split by ${splitVariableName}`;
+    return t("splitBy", { variable: splitVariableName });
   }
 
   // Use new chart selection logic

--- a/apps/web/src/components/chart/mean-bar-adhoc.tsx
+++ b/apps/web/src/components/chart/mean-bar-adhoc.tsx
@@ -21,6 +21,7 @@ type MeanBarAdhocProps = {
 
 export function MeanBarAdhoc({ variable, stats, datasetId, renderAsContent, ...props }: MeanBarAdhocProps) {
   const t = useTranslations("chartMetricsCard");
+  const tAdhoc = useTranslations("projectAdhocAnalysis");
   const { ref, exportPNG } = useChartExport();
 
   // Fetch split variables when datasetId is provided
@@ -50,12 +51,12 @@ export function MeanBarAdhoc({ variable, stats, datasetId, renderAsContent, ...p
       const splitVariable = allVariables.find((v: DatasetVariable) => v.name === splitVariableName);
       if (splitVariable) {
         const splitVariableLabel = splitVariable.label ?? splitVariable.name;
-        return `Split by ${splitVariableLabel}`;
+        return tAdhoc("splitBy", { variable: splitVariableLabel });
       }
     }
 
     // Fallback to variable name if no label found
-    return `Split by ${splitVariableName}`;
+    return tAdhoc("splitBy", { variable: splitVariableName });
   }
 
   // Find the stats for this variable using the helper function

--- a/apps/web/src/components/chart/metrics-cards.tsx
+++ b/apps/web/src/components/chart/metrics-cards.tsx
@@ -46,6 +46,7 @@ function MetricHelp({ metricKey, children }: { metricKey: "count" | "mean" | "me
 
 export function MetricsCards({ variable, stats, datasetId, renderAsContent, ...props }: BarAdhocProps) {
   const t = useTranslations("chartMetricsCard");
+  const tAdhoc = useTranslations("projectAdhocAnalysis");
   const variableStats = getVariableStats(variable, stats);
 
   // Fetch split variables when datasetId is provided
@@ -75,12 +76,12 @@ export function MetricsCards({ variable, stats, datasetId, renderAsContent, ...p
       const splitVariable = allVariables.find((v: DatasetVariable) => v.name === splitVariableName);
       if (splitVariable) {
         const splitVariableLabel = splitVariable.label ?? splitVariable.name;
-        return `Split by ${splitVariableLabel}`;
+        return tAdhoc("splitBy", { variable: splitVariableLabel });
       }
     }
     
     // Fallback to variable name if no label found
-    return `Split by ${splitVariableName}`;
+    return tAdhoc("splitBy", { variable: splitVariableName });
   }
 
   const content = (


### PR DESCRIPTION
## Summary

- Fixes internationalization for split variable descriptions in chart components
- Replaces hardcoded English template literals with `next-intl` translation keys, enabling proper German/English localization

## Changes

Added translation keys to `de.json` and `en.json`:
- German: `"splitBy": "aufgeteilt nach: {variable}"`
- English: `"splitBy": "Split by {variable}"`

Updated three chart components to use the translation key instead of hardcoded strings:
- `adhoc-chart.tsx`
- `mean-bar-adhoc.tsx` 
- `metrics-cards.tsx`

## Verification

All checks passed:
- ✅ Tests (41 passed)
- ✅ Translation checks
- ✅ Type checks
- ✅ Linting