### PR TITLE
Improve variable display UX in admin interface

### DIFF
--- a/apps/web/src/components/admin/dataset-splitvariables/split-variables-assignment.tsx
+++ b/apps/web/src/components/admin/dataset-splitvariables/split-variables-assignment.tsx
@@ -134,16 +134,14 @@ export function SplitVariablesAssignment({ datasetId, onRefresh }: SplitVariable
                         {isAssigning === variable.id ? "..." : <Plus className="h-3 w-3" />}
                       </Button>
                       <div className="min-w-0 flex-1 overflow-hidden">
-                        <p className="mb-1 truncate text-sm font-medium">{variable.name}</p>
-                        {variable.label && (
-                          <p className="text-muted-foreground mb-1 truncate text-xs">{variable.label}</p>
-                        )}
+                        {variable.label && <p className="mb-1 text-sm font-medium break-words">{variable.label}</p>}
+                        <p className="text-muted-foreground mb-1 truncate text-xs">{variable.name}</p>
                         <div className="flex flex-wrap gap-1">
                           <Badge variant="outline" className="shrink-0 text-xs">
-                            {variable.type}
+                            {variable.measure}
                           </Badge>
                           <Badge variant="outline" className="shrink-0 text-xs">
-                            {variable.measure}
+                            {variable.type}
                           </Badge>
                         </div>
                       </div>
@@ -196,16 +194,14 @@ export function SplitVariablesAssignment({ datasetId, onRefresh }: SplitVariable
                         {isRemoving === variable.id ? "..." : <X className="h-3 w-3" />}
                       </Button>
                       <div className="min-w-0 flex-1 overflow-hidden">
-                        <p className="mb-1 truncate text-sm font-medium">{variable.name}</p>
-                        {variable.label && (
-                          <p className="text-muted-foreground mb-1 truncate text-xs">{variable.label}</p>
-                        )}
+                        {variable.label && <p className="mb-1 text-sm font-medium break-words">{variable.label}</p>}
+                        <p className="text-muted-foreground mb-1 truncate text-xs">{variable.name}</p>
                         <div className="flex flex-wrap gap-1">
                           <Badge variant="outline" className="shrink-0 text-xs">
-                            {variable.type}
+                            {variable.measure}
                           </Badge>
                           <Badge variant="outline" className="shrink-0 text-xs">
-                            {variable.measure}
+                            {variable.type}
                           </Badge>
                         </div>
                       </div>

--- a/apps/web/src/components/admin/dataset-variableset/variable-assignment.tsx
+++ b/apps/web/src/components/admin/dataset-variableset/variable-assignment.tsx
@@ -149,16 +149,14 @@ export function VariableAssignment({ datasetId, selectedSetId, onRefresh }: Vari
                       {isAssigning === variable.id ? "..." : <Plus className="h-3 w-3" />}
                     </Button>
                     <div className="min-w-0 flex-1 overflow-hidden">
-                      <p className="mb-1 truncate text-sm font-medium">{variable.name}</p>
-                      {variable.label && (
-                        <p className="text-muted-foreground mb-1 truncate text-xs">{variable.label}</p>
-                      )}
+                      {variable.label && <p className="mb-1 text-sm font-medium break-words">{variable.label}</p>}
+                      <p className="text-muted-foreground mb-1 truncate text-xs">{variable.name}</p>
                       <div className="flex flex-wrap gap-1">
                         <Badge variant="outline" className="shrink-0 text-xs">
-                          {variable.type}
+                          {variable.measure}
                         </Badge>
                         <Badge variant="outline" className="shrink-0 text-xs">
-                          {variable.measure}
+                          {variable.type}
                         </Badge>
                       </div>
                     </div>
@@ -208,16 +206,14 @@ export function VariableAssignment({ datasetId, selectedSetId, onRefresh }: Vari
                       {isRemoving === variable.id ? "..." : <X className="h-3 w-3" />}
                     </Button>
                     <div className="min-w-0 flex-1 overflow-hidden">
-                      <p className="mb-1 truncate text-sm font-medium">{variable.name}</p>
-                      {variable.label && (
-                        <p className="text-muted-foreground mb-1 truncate text-xs">{variable.label}</p>
-                      )}
+                      {variable.label && <p className="mb-1 text-sm font-medium break-words">{variable.label}</p>}
+                      <p className="text-muted-foreground mb-1 truncate text-xs">{variable.name}</p>
                       <div className="flex flex-wrap gap-1">
                         <Badge variant="outline" className="shrink-0 text-xs">
-                          {variable.type}
+                          {variable.measure}
                         </Badge>
                         <Badge variant="outline" className="shrink-0 text-xs">
-                          {variable.measure}
+                          {variable.type}
                         </Badge>
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- Show variable labels first (bold, with line breaks) instead of technical variable names for better readability
- Display variable names below labels in muted text to maintain technical reference while prioritizing user-friendly descriptions
- Reorder type badges to show measurement type before data type for more relevant context in statistical analysis

These changes improve usability in the dataset variable sets and split variables management interfaces by creating a clearer visual hierarchy and ensuring full label visibility.