### PR TITLE
Standardize chart y-axis tick intervals to 20% increments

### DIFF
--- a/apps/web/src/components/chart/adhoc-chart.tsx
+++ b/apps/web/src/components/chart/adhoc-chart.tsx
@@ -186,6 +186,7 @@ export function AdhocChart({
                 tickMargin={10}
                 axisLine={false}
                 fontSize={10}
+                ticks={[0, 20, 40, 60, 80, 100]}
                 tickFormatter={(value) => `${value}%`}
               />
               <Bar dataKey="percentage" fill="var(--color-percentage)">
@@ -218,6 +219,7 @@ export function AdhocChart({
                 tickMargin={10}
                 axisLine={false}
                 fontSize={10}
+                ticks={[0, 20, 40, 60, 80, 100]}
                 tickFormatter={(value) => `${value}%`}
               />
               <YAxis

--- a/apps/web/src/components/chart/bar-adhoc.tsx
+++ b/apps/web/src/components/chart/bar-adhoc.tsx
@@ -44,6 +44,7 @@ export function BarAdhoc({ variable, stats, ...props }: BarAdhocProps) {
               tickMargin={10}
               axisLine={false}
               fontSize={10}
+              ticks={[0, 20, 40, 60, 80, 100]}
               tickFormatter={(value) => `${value}%`}
             />
             <Bar dataKey="percentage" fill="var(--color-percentage)">

--- a/apps/web/src/components/chart/horizontal-bar-adhoc.tsx
+++ b/apps/web/src/components/chart/horizontal-bar-adhoc.tsx
@@ -51,6 +51,7 @@ export function HorizontalBarAdhoc({ variable, stats, ...props }: BarAdhocProps)
               tickMargin={10}
               axisLine={false}
               fontSize={10}
+              ticks={[0, 20, 40, 60, 80, 100]}
               tickFormatter={(value) => `${value}%`}
             />
             <YAxis

--- a/apps/web/src/components/chart/horizontal-stacked-bar-adhoc.tsx
+++ b/apps/web/src/components/chart/horizontal-stacked-bar-adhoc.tsx
@@ -88,7 +88,7 @@ export const HorizontalStackedBarAdhoc = forwardRef<HTMLDivElement, HorizontalSt
               tickMargin={10}
               axisLine={false}
               fontSize={10}
-              ticks={[0, 25, 50, 75, 100]}
+              ticks={[0, 20, 40, 60, 80, 100]}
               tickFormatter={(value) => `${Math.round(value)}%`}
             />
             <YAxis
@@ -166,7 +166,7 @@ export const HorizontalStackedBarAdhoc = forwardRef<HTMLDivElement, HorizontalSt
             tickMargin={10}
             axisLine={false}
             fontSize={10}
-            ticks={[0, 25, 50, 75, 100]}
+            ticks={[0, 20, 40, 60, 80, 100]}
             tickFormatter={(value) => `${Math.round(value)}%`}
           />
           <YAxis


### PR DESCRIPTION
## Summary
- Standardize y-axis tick intervals to 20% increments (0, 20, 40, 60, 80, 100) for all adhoc bar charts displaying percentages
- Improve chart readability and visual consistency across all adhoc analysis chart types