### PR TITLE
Hide variable name in adhoc dataset selection menu

### DIFF
--- a/apps/web/src/components/project/adhoc-variableset-selector.tsx
+++ b/apps/web/src/components/project/adhoc-variableset-selector.tsx
@@ -107,9 +107,7 @@ function VariablesetNode({
               <button
                 className="hover:bg-accent hover:text-accent-foreground flex-1 cursor-pointer rounded px-1 py-0.5 text-left text-sm transition-colors"
                 onClick={() => onSelectVariable(variable, node)}>
-                {variable.label} {"("}
-                {variable.name}
-                {")"}
+                {variable.label}
               </button>
             </div>
           ))}


### PR DESCRIPTION
## Summary
- Simplify adhoc dataset selection menu by displaying only variable labels and removing internal variable names from the UI