### PR TITLE
Add editable measure field to dataset variable editor

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -242,7 +242,13 @@
           "placeholder": "Geben Sie ein beschreibendes Label ein"
         },
         "measure": {
-          "label": "Niveau"
+          "label": "Niveau",
+          "options": {
+            "nominal": "Nominal",
+            "ordinal": "Ordinal",
+            "scale": "Skala",
+            "unknown": "Unbekannt"
+          }
         },
         "missingValues": {
           "label": "Missing Values",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -242,7 +242,13 @@
           "placeholder": "Enter a descriptive label"
         },
         "measure": {
-          "label": "Measure"
+          "label": "Measure",
+          "options": {
+            "nominal": "Nominal",
+            "ordinal": "Ordinal",
+            "scale": "Scale",
+            "unknown": "Unknown"
+          }
         },
         "missingValues": {
           "label": "Missing Values",

--- a/apps/web/src/components/admin/dataset-editor/edit-dataset-variable-form.tsx
+++ b/apps/web/src/components/admin/dataset-editor/edit-dataset-variable-form.tsx
@@ -12,12 +12,17 @@ import { TextArrayEditor } from "@/components/form/text-array-editor";
 import { Button } from "@/components/ui/button";
 import { Field, FieldError, FieldGroup, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { DatasetVariable, updateDatasetVariableSchema } from "@/types/dataset-variable";
+
+// Define the allowed measure values
+const MEASURE_OPTIONS = ["nominal", "ordinal", "scale", "unknown"] as const;
 
 // Define the form schema
 const formSchema = z.object({
   id: z.uuid(),
   label: z.string().nullable(),
+  measure: z.enum(MEASURE_OPTIONS),
   missingValues: z.array(z.string()).nullable().optional(),
   missingRanges: z
     .record(z.string(), z.array(z.object({ lo: z.number(), hi: z.number() })))
@@ -41,6 +46,7 @@ export function EditDatasetVariableForm({ datasetVariable }: EditDatasetVariable
     defaultValues: {
       id: datasetVariable.id,
       label: datasetVariable.label,
+      measure: datasetVariable.measure,
       missingValues: Array.isArray(datasetVariable.missingValues) ? (datasetVariable.missingValues as string[]) : null,
     },
   });
@@ -120,12 +126,30 @@ export function EditDatasetVariableForm({ datasetVariable }: EditDatasetVariable
             </FieldGroup>
           </Field>
 
-          <Field>
-            <FieldLabel>{t("editVariable.form.measure.label")}</FieldLabel>
-            <FieldGroup>
-              <Input value={datasetVariable.measure} disabled />
-            </FieldGroup>
-          </Field>
+          <Controller
+            name="measure"
+            control={form.control}
+            render={({ field, fieldState }) => (
+              <Field data-invalid={fieldState.invalid}>
+                <FieldLabel htmlFor="measure">{t("editVariable.form.measure.label")}</FieldLabel>
+                <FieldGroup>
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger id="measure" className="w-full">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {MEASURE_OPTIONS.map((option) => (
+                        <SelectItem key={option} value={option}>
+                          {t(`editVariable.form.measure.options.${option}`)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </FieldGroup>
+                {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
+              </Field>
+            )}
+          />
         </div>
 
         <div className="flex justify-start gap-4">


### PR DESCRIPTION
## Summary
- Add editable select dropdown for the measurement scale field in the dataset variable editor, allowing users to choose between nominal, ordinal, scale, and unknown values
- Include translations for all measurement scale options in English and German