### PR TITLE
Refactor landing page to use empty state component

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -914,6 +914,8 @@
     "title": "Mitglieder von {name}"
   },
   "pageLanding": {
+    "emptyDescription": "Wählen Sie eine Organisation und ein Projekt aus der Seitenleiste aus, um zu beginnen.",
+    "emptyTitle": "Willkommen",
     "title": "Globale Startseite"
   },
   "pageProjectAdhoc": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -914,6 +914,8 @@
     "title": "{name} members"
   },
   "pageLanding": {
+    "emptyDescription": "Select an organization and project from the sidebar to get started.",
+    "emptyTitle": "Welcome",
     "title": "Global landing page"
   },
   "pageProjectAdhoc": {

--- a/apps/web/src/app/(app)/landing/layout.tsx
+++ b/apps/web/src/app/(app)/landing/layout.tsx
@@ -8,7 +8,7 @@ export default async function ProjectLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <SidebarLayout SidebarComponent={AppSidebar} SiteHeaderComponent={SiteHeader} siteHeaderTitle="Landing">
+    <SidebarLayout SidebarComponent={AppSidebar} SiteHeaderComponent={SiteHeader}>
       {children}
     </SidebarLayout>
   );

--- a/apps/web/src/app/(app)/landing/page.tsx
+++ b/apps/web/src/app/(app)/landing/page.tsx
@@ -1,9 +1,23 @@
+import { Inbox } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 import { PageLayout } from "@/components/page/page-layout";
+import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "@/components/ui/empty";
 
 export const dynamic = "force-dynamic";
 
 export default async function Dashboard() {
   const t = await getTranslations("pageLanding");
-  return <PageLayout data-testid="app.landing.page">{t("title")}</PageLayout>;
+  return (
+    <PageLayout data-testid="app.landing.page">
+      <Empty className="items-start justify-start">
+        <EmptyHeader className="items-start text-start">
+          <EmptyMedia variant="icon">
+            <Inbox />
+          </EmptyMedia>
+          <EmptyTitle>{t("emptyTitle")}</EmptyTitle>
+          <EmptyDescription>{t("emptyDescription")}</EmptyDescription>
+        </EmptyHeader>
+      </Empty>
+    </PageLayout>
+  );
 }


### PR DESCRIPTION
## Summary

- Replace landing page content with shadcn Empty component featuring an Inbox icon and welcoming message that instructs users to select an organization and project from the sidebar
- Remove "Landing" header title for a cleaner interface and better user experience