### PR TITLE
fix: await assertUserIsAdmin in server actions

### DIFF
--- a/apps/web/src/actions/member.ts
+++ b/apps/web/src/actions/member.ts
@@ -12,7 +12,7 @@ type AddMemberData = {
 };
 
 export async function addMember(organizationId: string, data: AddMemberData) {
-  assertUserIsAdmin();
+  await assertUserIsAdmin();
 
   // Check if the organization exists
   const [org] = await db.select().from(organizationTable).where(eq(organizationTable.id, organizationId)).limit(1);
@@ -50,7 +50,7 @@ export async function addMember(organizationId: string, data: AddMemberData) {
 }
 
 export async function updateMemberRole(organizationId: string, userId: string, role: "admin" | "owner" | "member") {
-  assertUserIsAdmin();
+  await assertUserIsAdmin();
 
   await db
     .update(memberTable)
@@ -64,7 +64,7 @@ export async function updateMemberRole(organizationId: string, userId: string, r
 }
 
 export async function removeMember(memberId: string) {
-  assertUserIsAdmin();
+  await assertUserIsAdmin();
 
   // Get the member to find the organizationId for revalidation
   const [member] = await db.select().from(memberTable).where(eq(memberTable.id, memberId)).limit(1);

--- a/apps/web/src/actions/organization.ts
+++ b/apps/web/src/actions/organization.ts
@@ -13,7 +13,7 @@ import { auth } from "@/lib/auth";
 import { assertUserIsAdmin } from "@/lib/dal";
 
 export async function create(data: CreateData) {
-  assertUserIsAdmin();
+  await assertUserIsAdmin();
   const session = await auth.api.getSession({
     headers: await headers(),
   });
@@ -34,11 +34,11 @@ export async function create(data: CreateData) {
 }
 
 export async function update(id: string, data: UpdateData) {
-  assertUserIsAdmin();
+  await assertUserIsAdmin();
   await db.update(entity).set(data).where(eq(entity.id, id));
 }
 
 export async function remove(id: string) {
-  assertUserIsAdmin();
+  await assertUserIsAdmin();
   await db.delete(entity).where(eq(entity.id, id));
 }

--- a/apps/web/src/actions/project.ts
+++ b/apps/web/src/actions/project.ts
@@ -10,16 +10,16 @@ import {
 import { assertUserIsAdmin } from "@/lib/dal";
 
 export async function create(data: CreateData) {
-  assertUserIsAdmin();
+  await assertUserIsAdmin();
   await db.insert(entity).values(data).returning();
 }
 
 export async function update(id: string, data: UpdateData) {
-  assertUserIsAdmin();
+  await assertUserIsAdmin();
   await db.update(entity).set(data).where(eq(entity.id, id)).returning();
 }
 
 export async function remove(id: string) {
-  assertUserIsAdmin();
+  await assertUserIsAdmin();
   await db.delete(entity).where(eq(entity.id, id));
 }

--- a/apps/web/src/actions/user.ts
+++ b/apps/web/src/actions/user.ts
@@ -13,7 +13,7 @@ import { assertUserIsAdmin } from "@/lib/dal";
 import { ServerActionNotAuthorizedException } from "@/lib/exception";
 
 export async function create(data: CreateData) {
-  assertUserIsAdmin();
+  await assertUserIsAdmin();
   await db.insert(entity).values(data).returning();
 }
 
@@ -47,11 +47,11 @@ export async function createWithInvitation(invitationId: string, data: CreateDat
 }
 
 export async function update(id: string, data: UpdateData) {
-  assertUserIsAdmin();
+  await assertUserIsAdmin();
   await db.update(entity).set(data).where(eq(entity.id, id)).returning();
 }
 
 export async function remove(id: string) {
-  assertUserIsAdmin();
+  await assertUserIsAdmin();
   await db.delete(entity).where(eq(entity.id, id));
 }

--- a/improvements.md
+++ b/improvements.md
@@ -180,7 +180,7 @@ A comprehensive list of improvements identified across code organization, qualit
   - Issue: `AUTH_SECRET: z.string().default("")` allows empty secrets
   - Fix: `AUTH_SECRET: z.string().min(32, "AUTH_SECRET must be at least 32 characters")`
 
-- [ ] **Await assertUserIsAdmin() calls**
+- [x] **Await assertUserIsAdmin() calls**
   - File: `apps/web/src/actions/user.ts` (line 16)
   - Issue: `assertUserIsAdmin()` not awaited, potentially bypassed auth
   - Fix: Add `await` before all `assertUserIsAdmin()` calls


### PR DESCRIPTION
## Summary

- Await assertUserIsAdmin() in server action files to ensure authorization checks run correctly.

## Changes

- apps/web/src/actions/member.ts
- apps/web/src/actions/project.ts
- apps/web/src/actions/user.ts
- apps/web/src/actions/organization.ts
- improvements.md (marked task as completed)

This fixes a potential bypass where the authorization check wasn't awaited.