### PR TITLE
Fix type validation for datasetVariableset attributes

### DIFF
--- a/packages/database/src/schema/app.ts
+++ b/packages/database/src/schema/app.ts
@@ -235,13 +235,13 @@ export const datasetVariableset = pgTable(
 );
 
 export const insertDatasetVariablesetSchema = createInsertSchema(datasetVariableset).extend({
-  attributes: datasetVariablesetAttributes.optional(),
+  attributes: datasetVariablesetAttributes.optional().nullable(),
 });
 export const selectDatasetVariablesetSchema = createSelectSchema(datasetVariableset).extend({
   attributes: datasetVariablesetAttributes.nullable(),
 });
 export const updateDatasetVariablesetSchema = createUpdateSchema(datasetVariableset).extend({
-  attributes: datasetVariablesetAttributes.optional(),
+  attributes: datasetVariablesetAttributes.optional().nullable(),
 });
 
 export type CreateDatasetVariablesetData = z.infer<typeof insertDatasetVariablesetSchema>;
@@ -286,7 +286,7 @@ export const datasetVariablesetItem = pgTable(
 );
 
 export const insertDatasetVariablesetItemSchema = createInsertSchema(datasetVariablesetItem).extend({
-  attributes: datasetVariablesetItemAttributes.optional(),
+  attributes: datasetVariablesetItemAttributes.optional().nullable(),
 });
 export const selectDatasetVariablesetItemSchema = createSelectSchema(datasetVariablesetItem).extend({
   attributes: datasetVariablesetItemAttributes.nullable(),


### PR DESCRIPTION
## Summary
- Extend datasetVariableset schemas to properly validate the attributes field with explicit type definitions
- Mark attributes as optional in insert/update schemas and nullable in select schema to match database constraints

This fixes potential type validation issues where the auto-generated schemas from Drizzle ORM do not properly handle the optional/nullable nature of the attributes field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Make dataset variableset and variableset item attributes optional/nullable across create, read, and update operations to allow more flexible attribute handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->