### PR TITLE
Fix ESLint warnings in admin dataset split variables test

### DIFF
--- a/packages/e2e-web/tests/admin-dataset-split-variables.spec.ts
+++ b/packages/e2e-web/tests/admin-dataset-split-variables.spec.ts
@@ -20,7 +20,7 @@ test.describe("Admin Dataset Split Variables", () => {
     await page.getByTestId("admin.datasets.create.upload").click();
     const uploadFile = page.getByTestId("file-upload-input");
     await uploadFile.setInputFiles("testdata/spss/demo.sav");
-    await page.waitForSelector("data-testid=app.admin.dataset.selected-file");
+    await expect(page.getByTestId("app.admin.dataset.selected-file")).toBeVisible();
     await page.getByTestId("app.admin.dataset.name-input").fill(datasetName);
     await page.getByTestId("app.admin.dataset.organization-trigger").click();
     await page.getByTestId("org-option-test-organization").click();
@@ -176,36 +176,38 @@ test.describe("Admin Dataset Split Variables", () => {
     // Wait for variables to be restored
     await expect(addButtons).toHaveCount(initialAvailableCount);
 
-    // Assign a couple of variables first if available
-    const buttonCount = await addButtons.count();
-    if (buttonCount > 0) {
-      await addButtons.first().click();
-      await expect(page.getByTestId("admin.dataset.splitvariables.assignment.remove").first()).toBeVisible();
-    }
-    if (buttonCount > 1) {
-      await addButtons.first().click();
-      await expect(page.getByTestId("admin.dataset.splitvariables.assignment.remove")).toHaveCount(2);
-    }
+    // Assign two variables to test search functionality in assigned section
+    // Ensure we have at least 2 variables available for this test
+    await expect(addButtons).toHaveCount(initialAvailableCount, { timeout: 5000 });
+
+    // Assign first variable
+    await addButtons.first().click();
+    await expect(page.getByTestId("admin.dataset.splitvariables.assignment.remove").first()).toBeVisible();
+
+    // Assign second variable
+    await addButtons.first().click();
+    await expect(page.getByTestId("admin.dataset.splitvariables.assignment.remove")).toHaveCount(2);
 
     // Test search in assigned variables section
     const assignedSearchInput = page.getByPlaceholder("Search variables...").last();
     const removeButtons = page.getByTestId("admin.dataset.splitvariables.assignment.remove");
     const initialAssignedCount = await removeButtons.count();
 
-    if (initialAssignedCount > 0) {
-      await assignedSearchInput.fill("nonexistent");
-      await expect(assignedSearchInput).toHaveValue("nonexistent");
+    // Verify we have assigned variables
+    expect(initialAssignedCount).toBeGreaterThan(0);
 
-      // Wait for search to filter assigned variables
-      const filteredAssignedCount = await removeButtons.count();
-      expect(filteredAssignedCount).toBeLessThanOrEqual(initialAssignedCount);
+    await assignedSearchInput.fill("nonexistent");
+    await expect(assignedSearchInput).toHaveValue("nonexistent");
 
-      // Clear assigned search
-      await assignedSearchInput.clear();
-      await expect(assignedSearchInput).toHaveValue("");
+    // Wait for search to filter assigned variables
+    const filteredAssignedCount = await removeButtons.count();
+    expect(filteredAssignedCount).toBeLessThanOrEqual(initialAssignedCount);
 
-      // Wait for assigned list to be restored
-      await expect(removeButtons).toHaveCount(initialAssignedCount);
-    }
+    // Clear assigned search
+    await assignedSearchInput.clear();
+    await expect(assignedSearchInput).toHaveValue("");
+
+    // Wait for assigned list to be restored
+    await expect(removeButtons).toHaveCount(initialAssignedCount);
   });
 });


### PR DESCRIPTION
## Summary

This PR fixes 10 ESLint warnings in the admin dataset split variables Playwright test by refactoring the code to follow Playwright best practices.

## Changes

- Replaced deprecated `page.waitForSelector()` with `expect().toBeVisible()` for better auto-waiting behavior
- Removed all conditional logic (`if` statements) from the test
- Removed conditional `expect` calls that could hide test failures
- Made the test deterministic by explicitly assigning two variables before testing search functionality
- Added explicit assertion to verify test preconditions

## Testing

All 12 tests pass successfully across all three browsers (Chromium, Firefox, WebKit).

## ESLint Warnings Fixed

- playwright/no-wait-for-selector (1 occurrence)
- playwright/no-conditional-in-test (4 occurrences)
- playwright/no-conditional-expect (6 occurrences)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for dataset variable assignment functionality with more deterministic test steps, enhanced timeout handling, and explicit assertions for search behavior and list restoration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->