### PR TITLE
max warnings

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,7 +7,7 @@
     "build": "unbuild",
     "stub": "unbuild --stub",
     "check-types": "tsc --noEmit",
-    "lint": "eslint ."
+    "lint": "eslint --max-warnings=0 ."
   },
   "dependencies": {
     "@repo/database": "workspace:*",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -11,7 +11,7 @@
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
     "check-types": "tsc --noEmit",
-    "lint": "eslint ."
+    "lint": "eslint --max-warnings=0 ."
   },
   "exports": {
     "./clients": {

--- a/packages/e2e-web/package.json
+++ b/packages/e2e-web/package.json
@@ -14,7 +14,7 @@
     "e2e:debug": "playwright test --debug",
     "e2e:ui": "playwright test --ui",
     "e2e:deps": "playwright install --with-deps",
-    "lint": "eslint ."
+    "lint": "eslint --max-warnings=0 ."
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores
* Updated lint scripts in the cli, database, and e2e-web packages so ESLint treats warnings as failures (lint now fails on any warnings), affecting local and CI lint runs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->