### PR TITLE
feat: add connection pool configuration to database clients

### DIFF
--- a/packages/database/src/clients/admin.ts
+++ b/packages/database/src/clients/admin.ts
@@ -4,6 +4,10 @@ import { env } from "../env.js";
 
 const pool = new pg.Pool({
   connectionString: env.DATABASE_URL,
+  // Connection pool configuration
+  max: 20, // maximum number of clients in the pool
+  idleTimeoutMillis: 30000, // close idle clients after 30 seconds
+  connectionTimeoutMillis: 2000, // timeout after 2 seconds when connecting a new client
 });
 const client = drizzle({
   client: pool,

--- a/packages/database/src/clients/default.ts
+++ b/packages/database/src/clients/default.ts
@@ -4,6 +4,10 @@ import { env } from "../env.js";
 
 const pool = new pg.Pool({
   connectionString: env.DATABASE_URL,
+  // Connection pool configuration
+  max: 20, // maximum number of clients in the pool
+  idleTimeoutMillis: 30000, // close idle clients after 30 seconds
+  connectionTimeoutMillis: 2000, // timeout after 2 seconds when connecting a new client
 });
 const client = drizzle({
   client: pool,


### PR DESCRIPTION
## Summary

- Add connection pool configuration to improve database connection management and prevent connection exhaustion

## Changes

- Configure `max: 20` to limit the maximum number of clients in the pool
- Set `idleTimeoutMillis: 30000` to close idle clients after 30 seconds and prevent connection leaks
- Set `connectionTimeoutMillis: 2000` to timeout after 2 seconds when connecting a new client and fail fast on connection issues

These settings follow node-postgres best practices and help prevent common production issues like connection pool exhaustion and hanging connections.

Fixes improvement from improvements.md (Code Quality - Medium Priority)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured database connection pool parameters with updated settings for maximum concurrent client connections, idle connection timeout duration, and connection establishment timeout threshold across database client instances.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->