### PR TITLE
Replace align-center with items-center

### DIFF
--- a/apps/web/src/app/(admin)/admin/page.tsx
+++ b/apps/web/src/app/(admin)/admin/page.tsx
@@ -9,7 +9,7 @@ export default async function Page() {
   return (
     <PageLayout title={t("title")} description={t("description")} data-testid="admin.page">
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-        <Card className="align-center flex flex-col justify-between shadow-xs">
+        <Card className="flex flex-col items-center justify-between shadow-xs">
           <CardHeader>
             <CardTitle>{t("organizations.title")}</CardTitle>
             <CardDescription>{t("organizations.description")}</CardDescription>
@@ -21,7 +21,7 @@ export default async function Page() {
           </CardFooter>
         </Card>
 
-        <Card className="align-center flex flex-col justify-between shadow-xs">
+        <Card className="flex flex-col items-center justify-between shadow-xs">
           <CardHeader>
             <CardTitle>{t("users.title")}</CardTitle>
             <CardDescription>{t("users.description")}</CardDescription>
@@ -33,7 +33,7 @@ export default async function Page() {
           </CardFooter>
         </Card>
 
-        <Card className="align-center flex flex-col justify-between shadow-xs">
+        <Card className="flex flex-col items-center justify-between shadow-xs">
           <CardHeader>
             <CardTitle>{t("projects.title")}</CardTitle>
             <CardDescription>{t("projects.description")}</CardDescription>
@@ -45,7 +45,7 @@ export default async function Page() {
           </CardFooter>
         </Card>
 
-        <Card className="align-center flex flex-col justify-between shadow-xs">
+        <Card className="flex flex-col items-center justify-between shadow-xs">
           <CardHeader>
             <CardTitle>{t("datasets.title")}</CardTitle>
             <CardDescription>{t("datasets.description")}</CardDescription>

--- a/apps/web/src/app/(auth)/auth/login/form.tsx
+++ b/apps/web/src/app/(auth)/auth/login/form.tsx
@@ -52,7 +52,7 @@ export function LoginForm(props: LoginFormProps) {
   return (
     <div className={cn("flex flex-col gap-6")}>
       <Card>
-        <CardHeader className="align-center flex justify-between space-y-1">
+        <CardHeader className="flex items-center justify-between space-y-1">
           <CardTitle className="text-2xl">{t("login.title")}</CardTitle>
           <LocaleSwitcher defaultValue={locale} />
         </CardHeader>

--- a/apps/web/src/app/(auth)/auth/sign-up/form.tsx
+++ b/apps/web/src/app/(auth)/auth/sign-up/form.tsx
@@ -53,7 +53,7 @@ export function SignUpForm({ className, ...props }: React.ComponentPropsWithoutR
     <div className={cn("flex flex-col gap-6", className)} {...props}>
       <Card>
         <CardHeader className="space-y-1">
-          <div className="align-center flex justify-between">
+          <div className="flex items-center justify-between">
             <CardTitle className="text-2xl">{t("signUp.title")}</CardTitle>
             <LocaleSwitcher defaultValue={locale} />
           </div>

--- a/apps/web/src/components/sign-up-form-with-invitation.tsx
+++ b/apps/web/src/components/sign-up-form-with-invitation.tsx
@@ -60,7 +60,7 @@ export function SignUpFormWithInvitation({ invitation }: SignUpFormWithInvitatio
     <div className={cn("flex flex-col gap-6")}>
       <Card>
         <CardHeader className="space-y-1">
-          <div className="align-center flex justify-between">
+          <div className="flex items-center justify-between">
             <CardTitle className="text-2xl">{t("authAcceptInvitation.title")}</CardTitle>
             <LocaleSwitcher defaultValue={locale} />
           </div>


### PR DESCRIPTION
## Summary
- replace non-Tailwind align-center utility with items-center in auth and admin layouts
- keep layout semantics consistent while aligning with Tailwind 4.1 utilities

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated visual alignment styling across authentication and admin pages for improved consistency in component presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->