### PR TITLE
Remove unnecessary items-center class from flex containers

### DIFF
--- a/apps/web/src/app/(admin)/admin/page.tsx
+++ b/apps/web/src/app/(admin)/admin/page.tsx
@@ -9,7 +9,7 @@ export default async function Page() {
   return (
     <PageLayout title={t("title")} description={t("description")} data-testid="admin.page">
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-        <Card className="flex flex-col items-center justify-between shadow-xs">
+        <Card className="flex flex-col justify-between shadow-xs">
           <CardHeader>
             <CardTitle>{t("organizations.title")}</CardTitle>
             <CardDescription>{t("organizations.description")}</CardDescription>
@@ -21,7 +21,7 @@ export default async function Page() {
           </CardFooter>
         </Card>
 
-        <Card className="flex flex-col items-center justify-between shadow-xs">
+        <Card className="flex flex-col justify-between shadow-xs">
           <CardHeader>
             <CardTitle>{t("users.title")}</CardTitle>
             <CardDescription>{t("users.description")}</CardDescription>
@@ -33,7 +33,7 @@ export default async function Page() {
           </CardFooter>
         </Card>
 
-        <Card className="flex flex-col items-center justify-between shadow-xs">
+        <Card className="flex flex-col justify-between shadow-xs">
           <CardHeader>
             <CardTitle>{t("projects.title")}</CardTitle>
             <CardDescription>{t("projects.description")}</CardDescription>
@@ -45,7 +45,7 @@ export default async function Page() {
           </CardFooter>
         </Card>
 
-        <Card className="flex flex-col items-center justify-between shadow-xs">
+        <Card className="flex flex-col justify-between shadow-xs">
           <CardHeader>
             <CardTitle>{t("datasets.title")}</CardTitle>
             <CardDescription>{t("datasets.description")}</CardDescription>

--- a/apps/web/src/app/(auth)/auth/login/form.tsx
+++ b/apps/web/src/app/(auth)/auth/login/form.tsx
@@ -52,7 +52,7 @@ export function LoginForm(props: LoginFormProps) {
   return (
     <div className={cn("flex flex-col gap-6")}>
       <Card>
-        <CardHeader className="flex items-center justify-between space-y-1">
+        <CardHeader className="flex justify-between space-y-1">
           <CardTitle className="text-2xl">{t("login.title")}</CardTitle>
           <LocaleSwitcher defaultValue={locale} />
         </CardHeader>

--- a/apps/web/src/app/(auth)/auth/sign-up/form.tsx
+++ b/apps/web/src/app/(auth)/auth/sign-up/form.tsx
@@ -53,7 +53,7 @@ export function SignUpForm({ className, ...props }: React.ComponentPropsWithoutR
     <div className={cn("flex flex-col gap-6", className)} {...props}>
       <Card>
         <CardHeader className="space-y-1">
-          <div className="flex items-center justify-between">
+          <div className="flex justify-between">
             <CardTitle className="text-2xl">{t("signUp.title")}</CardTitle>
             <LocaleSwitcher defaultValue={locale} />
           </div>

--- a/apps/web/src/components/sign-up-form-with-invitation.tsx
+++ b/apps/web/src/components/sign-up-form-with-invitation.tsx
@@ -55,7 +55,7 @@ export function SignUpFormWithInvitation({ invitation }: SignUpFormWithInvitatio
     <div className={cn("flex flex-col gap-6")}>
       <Card>
         <CardHeader className="space-y-1">
-          <div className="flex items-center justify-between">
+          <div className="flex justify-between">
             <CardTitle className="text-2xl">{t("authAcceptInvitation.title")}</CardTitle>
             <LocaleSwitcher defaultValue={locale} />
           </div>


### PR DESCRIPTION
## Summary

- Remove items-center class from flex containers in admin page cards
- Remove items-center from auth form headers where not needed for alignment
- Simplifies CSS by relying on justify-between for spacing

## Changes

- apps/web/src/app/(admin)/admin/page.tsx: Removed items-center from Card components
- apps/web/src/app/(auth)/auth/login/form.tsx: Removed items-center from CardHeader
- apps/web/src/app/(auth)/auth/sign-up/form.tsx: Removed items-center from header div
- apps/web/src/components/sign-up-form-with-invitation.tsx: Removed items-center from header div

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted vertical alignment of UI elements across authentication forms and dashboard components to refine layout presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->