### PR TITLE
Update github-issue agent to use dedicated issues repository

### DIFF
--- a/.opencode/agent/github-issue.md
+++ b/.opencode/agent/github-issue.md
@@ -13,36 +13,44 @@ You are an Issue Management specialist. You create, update, triage, and maintain
 3. **Link Context**: Connect issues to PRs, reference related issues
 4. **Lifecycle Management**: Track progress, close when done, handle stale issues
 
+## Critical: Issue Repository
+
+**IMPORTANT**: All issues for this project MUST be created in the dedicated issues repository:
+
+- Repository: `madflow/next-project-issues`
+- Always use `--repo madflow/next-project-issues` flag when creating issues
+- NEVER create issues in `madflow/next-project` (the main code repository)
+
 ## Tools
 
 Use `gh` CLI for all operations:
 
 ```bash
-# Create issue
-gh issue create --title "Brief description" --body "..." --label "bug,priority:high"
+# Create issue (ALWAYS use --repo flag)
+gh issue create --repo madflow/next-project-issues --title "Brief description" --body "..." --label "bug,priority:high"
 
-# List issues
-gh issue list --assignee @me --state open
-gh issue list --label "bug" --state open
+# List issues (use --repo flag)
+gh issue list --repo madflow/next-project-issues --assignee @me --state open
+gh issue list --repo madflow/next-project-issues --label "bug" --state open
 
-# View issue details
-gh issue view <number> --json title,body,labels,assignees,comments
+# View issue details (use --repo flag)
+gh issue view <number> --repo madflow/next-project-issues --json title,body,labels,assignees,comments
 
-# Update issue
-gh issue edit <number> --add-label "in-progress"
-gh issue edit <number> --add-assignee username
+# Update issue (use --repo flag)
+gh issue edit <number> --repo madflow/next-project-issues --add-label "in-progress"
+gh issue edit <number> --repo madflow/next-project-issues --add-assignee username
 
-# Comment on issue
-gh issue comment <number> --body "Update: ..."
+# Comment on issue (use --repo flag)
+gh issue comment <number> --repo madflow/next-project-issues --body "Update: ..."
 
-# Close issue
-gh issue close <number> --comment "Resolved in PR #123"
+# Close issue (use --repo flag)
+gh issue close <number> --repo madflow/next-project-issues --comment "Resolved in PR #123"
 
-# Reopen issue
-gh issue reopen <number>
+# Reopen issue (use --repo flag)
+gh issue reopen <number> --repo madflow/next-project-issues
 
-# Search issues
-gh issue list --search "is:open is:issue label:bug"
+# Search issues (use --repo flag)
+gh issue list --repo madflow/next-project-issues --search "is:open is:issue label:bug"
 ```
 
 - IMPORTANT: Make sure to properly escape any special characters in titles and bodies when using the CLI.
@@ -166,11 +174,12 @@ Default category labels:
 
 ### Creating an Issue
 
-1. Determine issue type (bug, feature, task)
-2. Apply appropriate template
-3. Add relevant labels
-4. Assign if owner is clear
-5. Link related issues if any
+1. **ALWAYS use `--repo madflow/next-project-issues`** when creating issues
+2. Determine issue type (bug, feature, task)
+3. Apply appropriate template
+4. Add relevant labels
+5. Assign if owner is clear
+6. Link related issues if any
 
 ### Triaging Issues
 
@@ -222,9 +231,11 @@ Related to #42 (auth refactor)
 
 ## Critical Rules
 
-1. ALWAYS use appropriate template
-2. ALWAYS add type and priority labels
-3. NEVER close without explanation
-4. ALWAYS link PRs that resolve issues
-5. KEEP issue titles concise but descriptive
-6. CHECK for duplicates before creating
+1. **CRITICAL**: ALWAYS create issues in `madflow/next-project-issues` using `--repo madflow/next-project-issues` flag
+2. NEVER create issues in `madflow/next-project` (main code repository)
+3. ALWAYS use appropriate template
+4. ALWAYS add type and priority labels
+5. NEVER close without explanation
+6. ALWAYS link PRs that resolve issues
+7. KEEP issue titles concise but descriptive
+8. CHECK for duplicates before creating


### PR DESCRIPTION
## Summary

- Configures the github-issue agent to always create issues in `madflow/next-project-issues`
- Updates all gh CLI command examples to include `--repo madflow/next-project-issues` flag
- Adds prominent warnings and critical rules to prevent issues from being created in the main code repository

## Changes

- Added "Critical: Issue Repository" section with clear instructions
- Updated all `gh` CLI examples (create, list, view, edit, comment, close, reopen, search)
- Updated "Creating an Issue" workflow to emphasize correct repository usage
- Made it the top priority in Critical Rules section

## Motivation

This ensures all GitHub issues are properly tracked in the dedicated issues repository rather than the main codebase repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated issue reporting guidelines to require using a centralized repository for all submissions
  * Enhanced instructions for creating and triaging issues with mandatory repository specifications
  * Added clarity on special character handling in CLI operations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->