### PR TITLE
Add sixth chart color (chart-6) CSS variable support

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -32,6 +32,7 @@
   --color-chart-3: var(--chart-3);
   --color-chart-4: var(--chart-4);
   --color-chart-5: var(--chart-5);
+  --color-chart-6: var(--chart-6);
   --color-sidebar: var(--sidebar);
   --color-sidebar-foreground: var(--sidebar-foreground);
   --color-sidebar-primary: var(--sidebar-primary);
@@ -65,6 +66,7 @@
   --chart-3: oklch(0.398 0.07 227.392);
   --chart-4: oklch(0.828 0.189 84.429);
   --chart-5: oklch(0.769 0.188 70.08);
+  --chart-6: oklch(0.724 0.162 336.2);
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.145 0 0);
   --sidebar-primary: oklch(0.205 0 0);
@@ -101,6 +103,7 @@
   --chart-3: oklch(0.769 0.188 70.08);
   --chart-4: oklch(0.627 0.265 303.9);
   --chart-5: oklch(0.645 0.246 16.439);
+  --chart-6: oklch(0.685 0.196 351.24);
   --sidebar: oklch(0.205 0 0);
   --sidebar-foreground: oklch(0.985 0 0);
   --sidebar-primary: oklch(0.488 0.243 264.376);

--- a/apps/web/src/app/themes.css
+++ b/apps/web/src/app/themes.css
@@ -4,6 +4,7 @@
   --chart-3: var(--color-blue-600);
   --chart-4: var(--color-blue-700);
   --chart-5: var(--color-blue-800);
+  --chart-6: var(--color-blue-900);
 }
 
 .theme-blue .theme-container {
@@ -18,6 +19,7 @@
   --chart-3: var(--color-blue-600);
   --chart-4: var(--color-blue-700);
   --chart-5: var(--color-blue-800);
+  --chart-6: var(--color-blue-900);
 
   @variant dark {
     --primary: var(--color-blue-500);
@@ -38,6 +40,7 @@
   --chart-3: var(--color-green-600);
   --chart-4: var(--color-green-700);
   --chart-5: var(--color-green-800);
+  --chart-6: var(--color-green-900);
   --sidebar-primary: var(--color-lime-600);
   --sidebar-primary-foreground: var(--color-lime-50);
   --sidebar-ring: var(--color-lime-400);
@@ -61,6 +64,7 @@
   --chart-3: var(--color-amber-600);
   --chart-4: var(--color-amber-700);
   --chart-5: var(--color-amber-800);
+  --chart-6: var(--color-amber-900);
   --sidebar-primary: var(--color-amber-600);
   --sidebar-primary-foreground: var(--color-amber-50);
   --sidebar-ring: var(--color-amber-400);
@@ -84,6 +88,7 @@
   --chart-3: var(--color-rose-600);
   --chart-4: var(--color-rose-700);
   --chart-5: var(--color-rose-800);
+  --chart-6: var(--color-rose-900);
   --sidebar-primary: var(--color-rose-600);
   --sidebar-primary-foreground: var(--color-rose-50);
   --sidebar-ring: var(--color-rose-400);
@@ -107,6 +112,7 @@
   --chart-3: var(--color-purple-600);
   --chart-4: var(--color-purple-700);
   --chart-5: var(--color-purple-800);
+  --chart-6: var(--color-purple-900);
   --sidebar-primary: var(--color-purple-600);
   --sidebar-primary-foreground: var(--color-purple-50);
   --sidebar-ring: var(--color-purple-400);
@@ -130,6 +136,7 @@
   --chart-3: var(--color-orange-600);
   --chart-4: var(--color-orange-700);
   --chart-5: var(--color-orange-800);
+  --chart-6: var(--color-orange-900);
   --sidebar-primary: var(--color-orange-600);
   --sidebar-primary-foreground: var(--color-orange-50);
   --sidebar-ring: var(--color-orange-400);
@@ -152,6 +159,7 @@
   --chart-3: var(--color-teal-600);
   --chart-4: var(--color-teal-700);
   --chart-5: var(--color-teal-800);
+  --chart-6: var(--color-teal-900);
   --sidebar-primary: var(--color-teal-600);
   --sidebar-primary-foreground: var(--color-teal-50);
   --sidebar-ring: var(--color-teal-400);
@@ -174,6 +182,7 @@
   --chart-3: var(--color-stone-600);
   --chart-4: var(--color-stone-700);
   --chart-5: var(--color-stone-800);
+  --chart-6: var(--color-stone-900);
   --sidebar-primary: var(--color-stone-600);
   --sidebar-primary-foreground: var(--color-stone-50);
   --sidebar-ring: var(--color-stone-400);
@@ -231,6 +240,7 @@
   --chart-3: var(--color-blue-600);
   --chart-4: var(--color-blue-700);
   --chart-5: var(--color-blue-800);
+  --chart-6: var(--color-blue-900);
 
   @media (min-width: 1024px) {
     --radius: 0.45em;
@@ -273,6 +283,7 @@
   --chart-3: var(--color-red-600);
   --chart-4: var(--color-red-700);
   --chart-5: var(--color-red-800);
+  --chart-6: var(--color-red-900);
   --sidebar-primary: var(--color-red-600);
   --sidebar-primary-foreground: var(--color-red-50);
   --sidebar-ring: var(--color-red-400);
@@ -296,6 +307,7 @@
   --chart-3: var(--color-yellow-600);
   --chart-4: var(--color-yellow-700);
   --chart-5: var(--color-yellow-800);
+  --chart-6: var(--color-yellow-900);
   --sidebar-primary: var(--color-yellow-600);
   --sidebar-primary-foreground: var(--color-yellow-50);
   --sidebar-ring: var(--color-yellow-400);
@@ -319,6 +331,7 @@
   --chart-3: var(--color-violet-600);
   --chart-4: var(--color-violet-700);
   --chart-5: var(--color-violet-800);
+  --chart-6: var(--color-violet-900);
   --sidebar-primary: var(--color-violet-600);
   --sidebar-primary-foreground: var(--color-violet-50);
   --sidebar-ring: var(--color-violet-400);


### PR DESCRIPTION
## Summary

- Adds --chart-6 CSS variable to light and dark modes in globals.css
- Adds --chart-6 to all 13 theme definitions in themes.css using color-900 shades
- Fixes display issue when charts have 6 dimensions (previously only 5 colors were defined in CSS despite TypeScript supporting 6)

## Changes

### globals.css
- Added --color-chart-6 to inline theme definition
- Added --chart-6 with pink/magenta color (oklch(0.724 0.162 336.2)) for light mode
- Added --chart-6 with adjusted pink (oklch(0.685 0.196 351.24)) for dark mode

### themes.css
- Added --chart-6 to all 13 themes (default, blue, green, amber, rose, purple, orange, teal, mono, scaled, red, yellow, violet)
- Each theme uses its respective color-900 shade to follow the existing pattern (300, 500, 600, 700, 800, 900)

## Testing
- All checks passed (make check)
- Chart components already support modulo 6 pattern and will automatically use the new variable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new sixth color option for charts, available across all theme variants (default, blue, green, amber, rose, purple, orange, teal, red, yellow, violet, and mono).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->