### PR TITLE
fix: include missingRanges in variableset endpoint responses

### DIFF
--- a/apps/web/src/dal/dataset-variableset.ts
+++ b/apps/web/src/dal/dataset-variableset.ts
@@ -157,6 +157,7 @@ async function getVariablesInSetFn(variablesetId: string, options: ListOptions =
       variableLabels: datasetVariable.variableLabels,
       valueLabels: datasetVariable.valueLabels,
       missingValues: datasetVariable.missingValues,
+      missingRanges: datasetVariable.missingRanges,
       orderIndex: datasetVariablesetItem.orderIndex,
       attributes: datasetVariablesetItem.attributes,
     })
@@ -204,6 +205,7 @@ async function getUnassignedVariablesFn(datasetId: string, options: ListOptions 
       variableLabels: datasetVariable.variableLabels,
       valueLabels: datasetVariable.valueLabels,
       missingValues: datasetVariable.missingValues,
+      missingRanges: datasetVariable.missingRanges,
     })
     .from(datasetVariable)
     .leftJoin(datasetVariablesetItem, eq(datasetVariable.id, datasetVariablesetItem.variableId))


### PR DESCRIPTION
## Summary

- Add missingRanges field to GET /api/variablesets/{id}/variables endpoint
- Add missingRanges field to GET /api/datasets/{id}/variablesets/{setId}/variables endpoint  
- Add missingRanges field to unassigned variables queries

This ensures consistent dataset variable metadata across all API endpoints.

## Changes

Updated apps/web/src/dal/dataset-variableset.ts:
- Added missingRanges to getVariablesInSetFn SELECT query (line 160)
- Added missingRanges to getUnassignedVariablesFn SELECT query (line 207)

## Testing

- All tests passed (41 Python tests)
- TypeScript type checking passed
- ESLint linting passed
- Translation checks passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced dataset variable queries to include missing range information in returned results for better data completeness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->