### PR TITLE
feat: add cancel buttons to admin edit forms

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -529,6 +529,7 @@
   },
   "adminUserEditForm": {
     "buttons": {
+      "cancel": "Abbrechen",
       "update": "Aktualisieren",
       "updating": "Wird aktualisiert..."
     },
@@ -643,6 +644,7 @@
       "title": "Datensatz bearbeiten"
     },
     "form": {
+      "cancel": "Abbrechen",
       "description": {
         "label": "Beschreibung",
         "placeholder": "Beschreibung des Datensatzes eingeben"

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -529,6 +529,7 @@
   },
   "adminUserEditForm": {
     "buttons": {
+      "cancel": "Cancel",
       "update": "Update",
       "updating": "Updating..."
     },
@@ -643,6 +644,7 @@
       "title": "Edit dataset"
     },
     "form": {
+      "cancel": "Cancel",
       "description": {
         "label": "Description",
         "placeholder": "Enter dataset description"

--- a/apps/web/src/components/admin/dataset/edit-dataset-form.tsx
+++ b/apps/web/src/components/admin/dataset/edit-dataset-form.tsx
@@ -132,7 +132,15 @@ export function EditDatasetForm({ dataset }: EditDatasetFormProps) {
         </FieldGroup>
       </Field>
 
-      <div className="pt-2">
+      <div className="flex gap-4 pt-2">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => router.push("/admin/datasets")}
+          disabled={form.formState.isSubmitting}
+          className="cursor-pointer">
+          {t("form.cancel")}
+        </Button>
         <Button
           type="submit"
           disabled={form.formState.isSubmitting}

--- a/apps/web/src/components/admin/organization/edit-organization-form.tsx
+++ b/apps/web/src/components/admin/organization/edit-organization-form.tsx
@@ -104,7 +104,7 @@ export function EditOrganizationForm({ organization }: FormEditProps) {
         <Button
           type="button"
           variant="outline"
-          onClick={() => router.back()}
+          onClick={() => router.push("/admin/organizations")}
           disabled={form.formState.isSubmitting}
           className="cursor-pointer">
           {t("organization.form.cancel")}

--- a/apps/web/src/components/admin/project/edit-project-form.tsx
+++ b/apps/web/src/components/admin/project/edit-project-form.tsx
@@ -176,7 +176,15 @@ export function EditProjectForm({ project }: EditProjectFormProps) {
         )}
       />
 
-      <div className="pt-2">
+      <div className="flex gap-4 pt-2">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => router.push("/admin/projects")}
+          disabled={form.formState.isSubmitting || isLoading}
+          className="cursor-pointer">
+          {t("form.cancel")}
+        </Button>
         <Button
           type="submit"
           disabled={form.formState.isSubmitting || isLoading || organizations.length === 0}

--- a/apps/web/src/components/admin/user/edit-user-form.tsx
+++ b/apps/web/src/components/admin/user/edit-user-form.tsx
@@ -136,13 +136,23 @@ export function EditUserForm({ user }: FormEditProps) {
           </Field>
         )}
       />
-      <Button
-        type="submit"
-        className="cursor-pointer"
-        data-testid="admin.users.edit.form.submit"
-        disabled={form.formState.isSubmitting}>
-        {form.formState.isSubmitting ? t("buttons.updating") : t("buttons.update")}
-      </Button>
+      <div className="flex gap-4">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => router.push("/admin/users")}
+          disabled={form.formState.isSubmitting}
+          className="cursor-pointer">
+          {t("buttons.cancel")}
+        </Button>
+        <Button
+          type="submit"
+          className="cursor-pointer"
+          data-testid="admin.users.edit.form.submit"
+          disabled={form.formState.isSubmitting}>
+          {form.formState.isSubmitting ? t("buttons.updating") : t("buttons.update")}
+        </Button>
+      </div>
     </form>
   );
 }


### PR DESCRIPTION
## Summary

- Add cancel buttons to all admin edit forms (Users, Projects, Organizations, Datasets)
- Users can now easily return to grid overview without saving changes
- Improves UX by providing clear navigation option

## Changes

### Edit Forms Updated
- **Users**: Added cancel button with navigation to `/admin/users`
- **Projects**: Added cancel button with navigation to `/admin/projects`  
- **Datasets**: Added cancel button with navigation to `/admin/datasets`
- **Organizations**: Updated existing cancel button to use direct navigation instead of `router.back()`

### Translations
- Added English translations for cancel buttons
- Added German translations for cancel buttons

### Technical Details
- All cancel buttons use `variant="outline"` for consistent styling
- Buttons are disabled during form submission to prevent navigation during save
- Cancel buttons navigate directly to respective grid overview pages
- Dataset Variables edit forms already had cancel buttons, so no changes were needed

## Testing
- ✅ All code quality checks passed (`make check`)
- ✅ TypeScript compilation successful
- ✅ ESLint checks passed
- ✅ Translation validation passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cancel buttons to admin forms for datasets, projects, users, and organizations. Cancel buttons navigate back to the respective admin list pages without saving changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->