### PR TITLE
Add language selection during organization invitation registration

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -1100,6 +1100,7 @@
     "form": {
       "confirmPassword": "Passwort bestätigen",
       "email": "E-Mail",
+      "language": "Sprache",
       "name": "Name",
       "password": "Passwort",
       "submit": "Registrieren"

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1100,6 +1100,7 @@
     "form": {
       "confirmPassword": "Confirm Password",
       "email": "Email",
+      "language": "Language",
       "name": "Name",
       "password": "Password",
       "submit": "Sign Up"

--- a/apps/web/src/actions/user.ts
+++ b/apps/web/src/actions/user.ts
@@ -34,7 +34,7 @@ export const create = withAdminAuth(async (data: CreateData) => {
 
 export async function createWithInvitation(
   invitationId: string,
-  data: { name: string; email: string; password: string; callbackURL?: string }
+  data: { name: string; email: string; password: string; callbackURL?: string; locale?: string }
 ) {
   validateCallbackURL(data.callbackURL);
 
@@ -52,6 +52,7 @@ export async function createWithInvitation(
       email: data.email,
       password: data.password,
       callbackURL: data.callbackURL,
+      locale: data.locale,
     },
     params: {
       invitationId: invitationId,

--- a/apps/web/src/app/(auth)/auth/sign-up/schema.ts
+++ b/apps/web/src/app/(auth)/auth/sign-up/schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { locales } from "@/i18n/config";
 
 export const signUpSchema = z
   .object({
@@ -6,6 +7,7 @@ export const signUpSchema = z
     name: z.string(),
     password: z.string().min(8),
     confirmPassword: z.string().min(8),
+    locale: z.enum(locales).optional(),
   })
   .refine((data) => data.password === data.confirmPassword, {
     message: "Passwords do not match",


### PR DESCRIPTION
## Summary
- Added language selection dropdown to registration form when accepting organization invitations
- Implemented auto-detection of browser language with fallback to current locale
- Integrated with existing next-intl internationalization system
- Language preference is persisted in user record and used for future sessions

## Changes
- Updated sign-up form schema to include optional locale field
- Modified user creation action to accept and pass locale parameter
- Added language selector component to registration form
- Implemented browser language auto-detection
- Added translations for language field label in both English and German

## Acceptance Criteria
- [x] Language selector is visible during organization invitation registration
- [x] Default language is auto-detected from browser/system settings
- [x] User can change the language selection before completing registration
- [x] Selected language persists after registration is complete
- [x] All available locales from the project are displayed as options (currently: de, en)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added language selection to the sign-up form with automatic browser language detection for pre-filled preference
* Users can now manually select their preferred language from available options during registration
* Sign-up form includes translated language labels in German and English

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->