### PR TITLE
fix: inject organization custom theme chart colors as CSS variables

### DIFF
--- a/apps/web/src/components/project/adhoc-analysis.tsx
+++ b/apps/web/src/components/project/adhoc-analysis.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 import { Suspense, useEffect, useState } from "react";
 import { useThemeConfig } from "@/components/active-theme";
 import { DatasetSelect } from "@/components/form/dataset-select";
+import { OrganizationThemeStyleInjector } from "@/context/organization-theme-context";
 import { useAdhocPersistence } from "@/hooks/use-adhoc-persistence";
 import { useDatasetStats } from "@/hooks/use-dataset-stats";
 import { type Project } from "@/types/project";
@@ -20,7 +21,7 @@ type AdHocAnalysisProps = {
 
 export function AdHocAnalysis({ project }: AdHocAnalysisProps) {
   const t = useTranslations("projectAdhocAnalysis");
-  const { setActiveTheme } = useThemeConfig();
+  const { activeTheme, setActiveTheme } = useThemeConfig();
   const { restoreState, saveDataset, saveCurrentSelection } = useAdhocPersistence(project.id);
 
   // Initialize state from localStorage
@@ -120,6 +121,7 @@ export function AdHocAnalysis({ project }: AdHocAnalysisProps) {
 
   return (
     <div className="theme-container flex gap-4">
+      <OrganizationThemeStyleInjector activeTheme={activeTheme} />
       <div className="flex w-64 max-w-64 min-w-64 flex-col gap-4">
         <DatasetSelect
           projectId={project.id}


### PR DESCRIPTION
## Summary

- Added OrganizationThemeStyleInjector component to dynamically inject organization custom theme chart colors as CSS variables
- Organization custom themes now correctly apply chart-1 through chart-6 colors to adhoc charts
- The component only activates for organization themes, predefined themes continue using static CSS

## Problem

Organization custom theme chart colors were not being applied to adhoc charts. When a user selected an organization theme, the body received a CSS class like `theme-{name}`, but since organization themes are stored in the database (not in static CSS), the chart color variables fell back to root defaults.

## Solution

Created `OrganizationThemeStyleInjector` that:
1. Detects when an organization custom theme is active using `resolveTheme()`
2. Generates and injects a `<style>` tag with CSS custom properties for chart-1 through chart-6
3. Targets `.theme-{themeName} .theme-container` to match the existing theme pattern in themes.css

Fixes madflow/next-project-issues#55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Updated CI/CD pipelines to use Python 3.13 environment
  * Upgraded minimum Python version requirement to 3.11 for the analysis service
  * Updated pandas dependency to version 3.0
  * Enhanced build workflow with improved caching and Poetry-based dependency management

* **New Features**
  * Added dynamic organization theme styling support, enabling organizations to customize chart colors at runtime

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->