### PR TITLE
fix: preserve numeric value order in pie chart legend

### DIFF
--- a/apps/web/src/components/chart/adhoc-chart.tsx
+++ b/apps/web/src/components/chart/adhoc-chart.tsx
@@ -23,14 +23,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import {
-  ChartConfig,
-  ChartContainer,
-  ChartLegend,
-  ChartLegendContent,
-  ChartTooltip,
-  ChartTooltipContent,
-} from "@/components/ui/chart";
+import { ChartConfig, ChartContainer, ChartLegend, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { useAppContext } from "@/context/app-context";
@@ -321,6 +314,18 @@ export function AdhocChart({
           };
         });
 
+        // Render custom legend that preserves the data order (sorted by numeric value)
+        const renderOrderedLegend = () => (
+          <div className="flex -translate-y-2 flex-wrap items-center justify-center gap-4 pt-3 *:basis-1/4 *:justify-center">
+            {pieData.map((item) => (
+              <div key={item.label} className="flex items-center gap-1.5">
+                <div className="h-2 w-2 shrink-0 rounded-[2px]" style={{ backgroundColor: item.fill }} />
+                <span className="text-xs">{item.label}</span>
+              </div>
+            ))}
+          </div>
+        );
+
         return (
           <ChartContainer config={pieChartConfig} ref={ref} data-export-filename={variable.name}>
             <PieChart>
@@ -337,11 +342,7 @@ export function AdhocChart({
                   formatter={(value: unknown) => `${formatChartValue(Number(value), PERCENTAGE_CHART_DECIMALS)}%`}
                 />
               </Pie>
-              <ChartLegend
-                fontSize={10}
-                content={<ChartLegendContent nameKey="label" />}
-                className="-translate-y-2 flex-wrap gap-2 *:basis-1/4 *:justify-center"
-              />
+              <ChartLegend fontSize={10} content={renderOrderedLegend} />
             </PieChart>
           </ChartContainer>
         );

--- a/apps/web/src/components/chart/pie-adhoc.tsx
+++ b/apps/web/src/components/chart/pie-adhoc.tsx
@@ -3,14 +3,7 @@
 import { DownloadIcon } from "lucide-react";
 import { Cell, LabelList, Pie, PieChart } from "recharts";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
-import {
-  ChartConfig,
-  ChartContainer,
-  ChartLegend,
-  ChartLegendContent,
-  ChartTooltip,
-  ChartTooltipContent,
-} from "@/components/ui/chart";
+import { ChartConfig, ChartContainer, ChartLegend, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
 import { useChartExport } from "@/hooks/use-chart-export";
 import { transformToRechartsPieData } from "@/lib/analysis-bridge";
 import { PERCENTAGE_CHART_DECIMALS, formatChartValue } from "@/lib/chart-constants";
@@ -39,7 +32,20 @@ export function PieAdhoc({ variable, stats, ...props }: PieAdhocProps) {
     };
   });
 
-  console.log(rechartsData);
+  // Render custom legend that preserves the data order (sorted by numeric value)
+  const renderOrderedLegend = () => (
+    <div className="flex -translate-y-2 flex-wrap items-center justify-center gap-4 pt-3 *:basis-1/4 *:justify-center">
+      {rechartsData.map((item, index) => {
+        const colorIndex = (index % 6) + 1;
+        return (
+          <div key={item.label} className="flex items-center gap-1.5">
+            <div className="h-2 w-2 shrink-0 rounded-[2px]" style={{ backgroundColor: `var(--chart-${colorIndex})` }} />
+            <span className="text-xs">{item.label}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
 
   return (
     <Card className="shadow-xs" {...props}>
@@ -63,11 +69,7 @@ export function PieAdhoc({ variable, stats, ...props }: PieAdhocProps) {
                 return <Cell key={`cell-${index}`} fill={`var(--chart-${colorIndex})`} />;
               })}
             </Pie>
-            <ChartLegend
-              fontSize={10}
-              content={<ChartLegendContent nameKey="label" />}
-              className="-translate-y-2 flex-wrap gap-2 *:basis-1/4 *:justify-center"
-            />
+            <ChartLegend fontSize={10} content={renderOrderedLegend} />
           </PieChart>
         </ChartContainer>
       </CardContent>

--- a/packages/e2e-web/tests/adhoc-analysis-pie-chart-ordering.spec.ts
+++ b/packages/e2e-web/tests/adhoc-analysis-pie-chart-ordering.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "@playwright/test";
+import { testUsers } from "../config";
+import { loginUser } from "../utils";
+
+test.describe("Adhoc Analysis - Pie Chart Legend Ordering", () => {
+  test("should preserve numeric value order in pie chart legend", async ({ page }) => {
+    // Login as admin
+    await page.goto("/");
+    await loginUser(page, testUsers.admin.email, testUsers.admin.password);
+
+    // Navigate to adhoc analysis for Test Project
+    await page.goto("/project/test-project/adhoc");
+    await expect(page.getByTestId("app.project.adhoc")).toBeVisible();
+
+    // Select SPSS Beispielumfrage dataset
+    await page.getByTestId("app.dropdown.dataset.trigger").click();
+    await page.getByText("SPSS Beispielumfrage").click();
+
+    const datasetTrigger = page.getByTestId("app.dropdown.dataset.trigger");
+    await expect(datasetTrigger).toContainText("SPSS Beispielumfrage");
+
+    // Expand "Bildung und Beruf" group
+    const bildungGroup = page.getByTestId("variable-group-Bildung und Beruf");
+    await expect(bildungGroup).toBeVisible();
+
+    const expandButton = page.getByTestId("variable-group-expand-Bildung und Beruf");
+    await expandButton.click();
+
+    // Select "Höchster Abschluss" variable (degree)
+    const degreeVariable = page.getByTestId("variable-item-degree");
+    await expect(degreeVariable).toBeVisible();
+    await degreeVariable.click();
+
+    // Wait for chart type selector to load
+    const chartTypeSelector = page.getByTestId("chart-type-selector");
+    await expect(chartTypeSelector).toBeVisible();
+
+    // Expected order based on numeric values (0.0, 1.0, 2.0, 3.0, 4.0)
+    const expectedOrder = [
+      "Niedriger als High School", // 0.0
+      "High School", // 1.0
+      "Junior College", // 2.0
+      "Bachelor", // 3.0
+      "Universitätsabschluss", // 4.0
+    ];
+
+    // Switch to pie chart
+    const pieChartButton = page.getByTestId("chart-type-pie");
+    await expect(pieChartButton).toBeVisible();
+    await pieChartButton.click();
+
+    // Wait for pie chart to load
+    const pieChartContent = page.getByTestId("chart-content-pie");
+    await expect(pieChartContent).toBeVisible();
+
+    // Verify the legend order matches the expected numeric order
+    // The custom legend uses spans with text-xs class inside divs with items-center gap-1.5
+    const legendItems = pieChartContent.locator(".recharts-legend-wrapper span.text-xs");
+
+    // Verify the legend items are in the correct order (sorted by numeric value)
+    await expect(legendItems).toHaveText(expectedOrder);
+  });
+});


### PR DESCRIPTION
## Summary

- Fixed pie chart legend displaying labels in alphabetical order instead of preserving numeric value order
- Implemented custom legend renderers that iterate over the pie data array directly (already sorted by numeric value)
- Added E2E test to verify legend ordering is preserved

## Problem

The pie chart legend was showing:
- Bachelor
- High School
- Junior College
- Niedriger als High School
- Universitatsabschluss

Instead of the correct order based on numeric values (0.0, 1.0, 2.0, 3.0, 4.0):
- Niedriger als High School
- High School
- Junior College
- Bachelor
- Universitatsabschluss

## Root Cause

The ChartLegend component from Recharts was generating its own payload for the legend, which did not preserve the order of the data array. The data was correctly sorted in transformToRechartsPieData(), but the legend rendering did not respect this order.

## Solution

Created custom legend rendering functions (renderOrderedLegend) in both:
- apps/web/src/components/chart/adhoc-chart.tsx
- apps/web/src/components/chart/pie-adhoc.tsx

These custom legend renderers iterate over the pieData array directly, ensuring the legend items appear in the correct order.

Closes https://github.com/madflow/next-project-issues/issues/55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pie chart legends now maintain proper numeric ordering of data items for consistent data presentation

* **Tests**
  * Added end-to-end testing to verify pie chart legend items display in the correct numeric sequence

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->