### PR TITLE
Fix avatar delete authorization

### DIFF
--- a/apps/web/src/actions/avatar.ts
+++ b/apps/web/src/actions/avatar.ts
@@ -4,6 +4,8 @@ import { DeleteObjectCommand, PutObjectCommand, S3ServiceException } from "@aws-
 import { randomUUID } from "crypto";
 import { fileTypeFromBuffer } from "file-type";
 import { env } from "@/env";
+import { USER_ADMIN_ROLE } from "@/lib/auth";
+import { canDeleteAvatarForUser } from "@/lib/avatar-authorization";
 import { ServerActionNotAuthorizedException } from "@/lib/exception";
 import { getSessionOrThrow, withAuth } from "@/lib/server-action-utils";
 import { getS3Client } from "@/lib/storage";
@@ -160,6 +162,18 @@ export const uploadAvatar = withAuth(async ({ file, userId }: UploadAvatarParams
 });
 
 export async function deleteAvatar(userId: string, filename: string) {
+  const session = await getSessionOrThrow();
+
+  if (
+    !canDeleteAvatarForUser({
+      sessionUserId: session.user.id,
+      targetUserId: userId,
+      isAdmin: session.user.role === USER_ADMIN_ROLE,
+    })
+  ) {
+    throw new ServerActionNotAuthorizedException("User ID mismatch");
+  }
+
   const s3Client = getS3Client();
   try {
     // Construct the full S3 key with the correct path

--- a/apps/web/src/lib/avatar-authorization.test.ts
+++ b/apps/web/src/lib/avatar-authorization.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { canDeleteAvatarForUser } from "./avatar-authorization";
+
+describe("canDeleteAvatarForUser", () => {
+  test("allows a user to delete their own avatar", () => {
+    assert.equal(
+      canDeleteAvatarForUser({
+        sessionUserId: "user-1",
+        targetUserId: "user-1",
+        isAdmin: false,
+      }),
+      true
+    );
+  });
+
+  test("allows an admin to delete another user's avatar", () => {
+    assert.equal(
+      canDeleteAvatarForUser({
+        sessionUserId: "admin-1",
+        targetUserId: "user-2",
+        isAdmin: true,
+      }),
+      true
+    );
+  });
+
+  test("rejects deleting another user's avatar without admin access", () => {
+    assert.equal(
+      canDeleteAvatarForUser({
+        sessionUserId: "user-1",
+        targetUserId: "user-2",
+        isAdmin: false,
+      }),
+      false
+    );
+  });
+});

--- a/apps/web/src/lib/avatar-authorization.ts
+++ b/apps/web/src/lib/avatar-authorization.ts
@@ -1,0 +1,9 @@
+export type AvatarDeletionAuthorizationParams = {
+  sessionUserId: string;
+  targetUserId: string;
+  isAdmin: boolean;
+};
+
+export function canDeleteAvatarForUser({ sessionUserId, targetUserId, isAdmin }: AvatarDeletionAuthorizationParams) {
+  return isAdmin || sessionUserId === targetUserId;
+}


### PR DESCRIPTION
## Summary
- add a server-side session ownership check before deleting avatars
- keep admin users allowed to delete any avatar
- add focused tests for the authorization rule

## Verification
- `pnpm --filter @app/web test -- src/lib/avatar-authorization.test.ts`
- `make check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced authorization checks on avatar deletion. Users can now only delete their own avatars unless they have admin privileges. Unauthorized deletion attempts are properly rejected with appropriate error handling.

* **Tests**
  * Added tests for avatar deletion authorization, covering non-admin users deleting their own avatars, admins deleting other users' avatars, and permission denial scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->