### PR TITLE
proxyClientMaxBodySize raised

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -7,6 +7,7 @@ const nextConfig = {
   transpilePackages: ["@t3-oss/env-nextjs", "@t3-oss/env-core"],
   typedRoutes: true,
   experimental: {
+    proxyClientMaxBodySize: "100mb",
     serverActions: {
       bodySizeLimit: "100mb",
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration to increase the maximum client request body size limit to 100MB, enabling support for larger file uploads and data submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->