### PR TITLE
Add count-based organization chart palettes

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -912,7 +912,19 @@
       "theme": {
         "add": "Thema hinzufügen",
         "addFirst": "Erstes Thema hinzufügen",
+        "basePalette": {
+          "description": "Grundlegende Fallback-Farben für Diagramme. Anzahl-spezifische Paletten erben diese Farben, sofern sie nicht überschrieben werden.",
+          "title": "Basispalette"
+        },
         "colorHelp": "Geben Sie eine 6-stellige Hex-Farbe wie #3b82f6 ein.",
+        "countPalettes": {
+          "derivedHelp": "Verwendet die aktuelle Basispalette, bis Sie diese Farbe überschreiben.",
+          "description": "Überschreiben Sie Diagrammfarben abhängig von der Anzahl sichtbarer Werte oder Segmente im Diagramm.",
+          "multiSeriesDescription": "Wird verwendet, wenn ein Diagramm {count} sichtbare Kategorien oder Segmente rendert.",
+          "paletteTitle": "Palette für {count}",
+          "singleSeriesDescription": "Wird für Einzelserien-Diagramme wie Balken-, horizontale Balken-, Multi-Response- und Mittelwert/Median-Diagramme verwendet.",
+          "title": "Anzahl-spezifische Paletten"
+        },
         "empty": "Noch keine Themen konfiguriert",
         "nameHelp": "Nur Buchstaben, Zahlen, Bindestriche (-) und Unterstriche (_) sind erlaubt. Leerzeichen werden in Bindestriche umgewandelt.",
         "namePlaceholder": "Themenname eingeben",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -912,7 +912,19 @@
       "theme": {
         "add": "Add Theme",
         "addFirst": "Add First Theme",
+        "basePalette": {
+          "description": "Base fallback colors for charts. Count-specific palettes inherit from these unless overridden.",
+          "title": "Base Palette"
+        },
         "colorHelp": "Enter a 6-digit hex color like #3b82f6.",
+        "countPalettes": {
+          "derivedHelp": "Uses the current base palette until you override this color.",
+          "description": "Override chart colors by the number of visible values or segments in the chart.",
+          "multiSeriesDescription": "Used when a chart renders {count} visible categories or segments.",
+          "paletteTitle": "Palette for {count}",
+          "singleSeriesDescription": "Used for single-series charts like bar, horizontal bar, multi-response, and mean/median charts.",
+          "title": "Count-Specific Palettes"
+        },
         "empty": "No themes configured yet",
         "nameHelp": "Only letters, numbers, hyphens (-), and underscores (_) are allowed. Spaces will be converted to hyphens.",
         "namePlaceholder": "Enter theme name",

--- a/apps/web/src/components/admin/organization/organization-settings-editor.tsx
+++ b/apps/web/src/components/admin/organization/organization-settings-editor.tsx
@@ -7,8 +7,15 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { isValidThemeColor, normalizeThemeColorInput, organizationThemeColorKeys } from "@/lib/organization-theme";
-import { type OrganizationSettings, ThemeItem } from "@/types/organization";
+import {
+  getThemeColorKeysForCount,
+  isValidThemeColor,
+  normalizeThemeColorInput,
+  organizationThemeColorKeys,
+  organizationThemePaletteCountKeys,
+  resolveThemePaletteForCount,
+} from "@/lib/organization-theme";
+import { type OrganizationSettings, type ThemeChartColors, ThemeItem } from "@/types/organization";
 import { DEFAULT_THEME } from "./defaults";
 
 type OrganizationSettingsEditorProps = {
@@ -35,6 +42,7 @@ export function OrganizationSettingsEditor({
     const newTheme: ThemeItem = {
       name: `new-theme-${themes.length + 1}`,
       chartColors: { ...DEFAULT_THEME.chartColors },
+      chartColorPalettes: {},
     };
     updateSettings([...themes, newTheme]);
   };
@@ -105,7 +113,81 @@ export function OrganizationSettingsEditor({
     }
   };
 
+  const updateThemePaletteColor = (index: number, paletteCountKey: string, colorKey: string, color: string) => {
+    const theme = themes[index];
+    if (!theme) {
+      return;
+    }
+
+    const normalizedColor = normalizeThemeColorInput(color);
+    const fieldId = `${index}-${paletteCountKey}-${colorKey}`;
+    const isValid = isValidThemeColor(normalizedColor);
+    const nextColorValue = isValid ? normalizedColor : color;
+    const currentPalette = theme.chartColorPalettes?.[paletteCountKey as keyof NonNullable<ThemeItem["chartColorPalettes"]>] || {};
+    const nextThemes = [...themes];
+    nextThemes[index] = {
+      ...theme,
+      chartColorPalettes: {
+        ...theme.chartColorPalettes,
+        [paletteCountKey]: {
+          ...currentPalette,
+          [colorKey]: nextColorValue,
+        },
+      },
+    };
+    setThemes(nextThemes);
+
+    setInvalidColorFields((current) => {
+      if (isValid) {
+        const next = { ...current };
+        delete next[fieldId];
+        return next;
+      }
+
+      return { ...current, [fieldId]: true };
+    });
+
+    if (!isValid) {
+      return;
+    }
+
+    onChangeAction({ themes: nextThemes });
+  };
+
   const colorKeys = organizationThemeColorKeys;
+
+  const getBaseColorValue = (theme: ThemeItem, colorKey: (typeof organizationThemeColorKeys)[number]) => {
+    const currentColor = theme.chartColors?.[colorKey] || DEFAULT_THEME.chartColors?.[colorKey];
+    const normalizedColor = normalizeThemeColorInput(currentColor ?? "");
+    const safeColorValue = isValidThemeColor(normalizedColor)
+      ? normalizedColor
+      : (DEFAULT_THEME.chartColors?.[colorKey] ?? "#000000");
+
+    return { currentColor, safeColorValue };
+  };
+
+  const getPaletteColorValue = (
+    theme: ThemeItem,
+    paletteCount: number,
+    paletteCountKey: string,
+    colorKey: (typeof organizationThemeColorKeys)[number]
+  ) => {
+    const resolvedPalette = resolveThemePaletteForCount(theme, paletteCount);
+    const explicitPalette = theme.chartColorPalettes?.[
+      paletteCountKey as keyof NonNullable<ThemeItem["chartColorPalettes"]>
+    ] as ThemeChartColors | undefined;
+    const currentColor = explicitPalette?.[colorKey] ?? resolvedPalette[colorKey] ?? DEFAULT_THEME.chartColors?.[colorKey];
+    const normalizedColor = normalizeThemeColorInput(currentColor ?? "");
+    const safeColorValue = isValidThemeColor(normalizedColor)
+      ? normalizedColor
+      : (DEFAULT_THEME.chartColors?.[colorKey] ?? "#000000");
+
+    return {
+      currentColor,
+      safeColorValue,
+      isDerived: explicitPalette?.[colorKey] === undefined,
+    };
+  };
 
   return (
     <div className="space-y-6">
@@ -155,45 +237,131 @@ export function OrganizationSettingsEditor({
               </div>
             </CardHeader>
             <CardContent>
-              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                {colorKeys.map((colorKey) => {
-                  const currentColor = theme.chartColors?.[colorKey] || DEFAULT_THEME.chartColors?.[colorKey];
-                  const normalizedColor = normalizeThemeColorInput(currentColor ?? "");
-                  const safeColorValue = isValidThemeColor(normalizedColor)
-                    ? normalizedColor
-                    : (DEFAULT_THEME.chartColors?.[colorKey] ?? "#000000");
-                  const isInvalid = invalidColorFields[`${themeIndex}-${colorKey}`] === true;
-                  return (
-                    <div key={colorKey} className="space-y-2">
-                      <Label htmlFor={`${themeIndex}-${colorKey}`} className="text-sm font-medium">
-                        {colorKey}
-                      </Label>
-                      <div className="flex items-center space-x-2">
-                        <input
-                          id={`${themeIndex}-${colorKey}`}
-                          type="color"
-                          value={safeColorValue}
-                          onChange={(e) => updateThemeColor(themeIndex, colorKey, e.target.value)}
-                          disabled={readOnly}
-                          className="border-input h-8 w-8 cursor-pointer rounded border disabled:cursor-not-allowed"
-                        />
-                        <Input
-                          value={currentColor}
-                          data-testid={`theme-color-${themeIndex}-${colorKey}`}
-                          onChange={(e) => updateThemeColor(themeIndex, colorKey, e.target.value)}
-                          placeholder="#000000"
-                          pattern="^#[0-9A-Fa-f]{6}$"
-                          aria-invalid={isInvalid}
-                          className="flex-1 font-mono text-sm"
-                          readOnly={readOnly}
-                        />
+              <div className="space-y-6">
+                <div className="space-y-3">
+                  <div>
+                    <h4 className="text-sm font-medium">{t("organization.settings.theme.basePalette.title")}</h4>
+                    <p className="text-muted-foreground text-xs">{t("organization.settings.theme.basePalette.description")}</p>
+                  </div>
+                  <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                    {colorKeys.map((colorKey) => {
+                      const { currentColor, safeColorValue } = getBaseColorValue(theme, colorKey);
+                      const isInvalid = invalidColorFields[`${themeIndex}-${colorKey}`] === true;
+
+                      return (
+                        <div key={colorKey} className="space-y-2">
+                          <Label htmlFor={`${themeIndex}-${colorKey}`} className="text-sm font-medium">
+                            {colorKey}
+                          </Label>
+                          <div className="flex items-center space-x-2">
+                            <input
+                              id={`${themeIndex}-${colorKey}`}
+                              type="color"
+                              value={safeColorValue}
+                              onChange={(e) => updateThemeColor(themeIndex, colorKey, e.target.value)}
+                              disabled={readOnly}
+                              className="border-input h-8 w-8 cursor-pointer rounded border disabled:cursor-not-allowed"
+                            />
+                            <Input
+                              value={currentColor}
+                              data-testid={`theme-color-${themeIndex}-${colorKey}`}
+                              onChange={(e) => updateThemeColor(themeIndex, colorKey, e.target.value)}
+                              placeholder="#000000"
+                              pattern="^#[0-9A-Fa-f]{6}$"
+                              aria-invalid={isInvalid}
+                              className="flex-1 font-mono text-sm"
+                              readOnly={readOnly}
+                            />
+                          </div>
+                          {isInvalid && (
+                            <p className="text-destructive text-xs">{t("organization.settings.theme.colorHelp")}</p>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                <div className="space-y-4 border-t pt-4">
+                  <div>
+                    <h4 className="text-sm font-medium">{t("organization.settings.theme.countPalettes.title")}</h4>
+                    <p className="text-muted-foreground text-xs">
+                      {t("organization.settings.theme.countPalettes.description")}
+                    </p>
+                  </div>
+                  {organizationThemePaletteCountKeys.map((paletteCountKey) => {
+                    const paletteCount = Number(paletteCountKey);
+                    const paletteKeys = getThemeColorKeysForCount(paletteCount);
+
+                    return (
+                      <div key={paletteCountKey} className="space-y-3 rounded-md border p-4">
+                        <div>
+                          <h5 className="text-sm font-medium">
+                            {t("organization.settings.theme.countPalettes.paletteTitle", { count: paletteCount })}
+                          </h5>
+                          <p className="text-muted-foreground text-xs">
+                            {paletteCount === 1
+                              ? t("organization.settings.theme.countPalettes.singleSeriesDescription")
+                              : t("organization.settings.theme.countPalettes.multiSeriesDescription", {
+                                  count: paletteCount,
+                                })}
+                          </p>
+                        </div>
+                        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                          {paletteKeys.map((colorKey) => {
+                            const { currentColor, safeColorValue, isDerived } = getPaletteColorValue(
+                              theme,
+                              paletteCount,
+                              paletteCountKey,
+                              colorKey
+                            );
+                            const isInvalid = invalidColorFields[`${themeIndex}-${paletteCountKey}-${colorKey}`] === true;
+
+                            return (
+                              <div key={`${paletteCountKey}-${colorKey}`} className="space-y-2">
+                                <Label htmlFor={`${themeIndex}-${paletteCountKey}-${colorKey}`} className="text-sm font-medium">
+                                  {colorKey}
+                                </Label>
+                                <div className="flex items-center space-x-2">
+                                  <input
+                                    id={`${themeIndex}-${paletteCountKey}-${colorKey}`}
+                                    type="color"
+                                    value={safeColorValue}
+                                    onChange={(e) =>
+                                      updateThemePaletteColor(themeIndex, paletteCountKey, colorKey, e.target.value)
+                                    }
+                                    disabled={readOnly}
+                                    className="border-input h-8 w-8 cursor-pointer rounded border disabled:cursor-not-allowed"
+                                  />
+                                  <Input
+                                    value={currentColor}
+                                    data-testid={`theme-palette-color-${themeIndex}-${paletteCountKey}-${colorKey}`}
+                                    onChange={(e) =>
+                                      updateThemePaletteColor(themeIndex, paletteCountKey, colorKey, e.target.value)
+                                    }
+                                    placeholder="#000000"
+                                    pattern="^#[0-9A-Fa-f]{6}$"
+                                    aria-invalid={isInvalid}
+                                    className="flex-1 font-mono text-sm"
+                                    readOnly={readOnly}
+                                  />
+                                </div>
+                                {isDerived && !isInvalid && (
+                                  <p className="text-muted-foreground text-xs">
+                                    {t("organization.settings.theme.countPalettes.derivedHelp")}
+                                  </p>
+                                )}
+                                {isInvalid && (
+                                  <p className="text-destructive text-xs">{t("organization.settings.theme.colorHelp")}</p>
+                                )}
+                              </div>
+                            );
+                          })}
+                        </div>
                       </div>
-                      {isInvalid && (
-                        <p className="text-destructive text-xs">{t("organization.settings.theme.colorHelp")}</p>
-                      )}
-                    </div>
-                  );
-                })}
+                    );
+                  })}
+                </div>
               </div>
             </CardContent>
           </Card>

--- a/apps/web/src/components/admin/organization/organization-settings-editor.tsx
+++ b/apps/web/src/components/admin/organization/organization-settings-editor.tsx
@@ -13,6 +13,7 @@ import {
   normalizeThemeColorInput,
   organizationThemeColorKeys,
   organizationThemePaletteCountKeys,
+  sanitizeThemesPayload,
   resolveThemePaletteForCount,
 } from "@/lib/organization-theme";
 import { type OrganizationSettings, type ThemeChartColors, ThemeItem } from "@/types/organization";
@@ -151,7 +152,8 @@ export function OrganizationSettingsEditor({
       return;
     }
 
-    onChangeAction({ themes: nextThemes });
+    const sanitizedThemes = sanitizeThemesPayload(nextThemes, themes);
+    onChangeAction({ themes: sanitizedThemes });
   };
 
   const colorKeys = organizationThemeColorKeys;

--- a/apps/web/src/components/chart/adhoc-chart.tsx
+++ b/apps/web/src/components/chart/adhoc-chart.tsx
@@ -17,10 +17,16 @@ import {
   getComputedExportPalette,
   sanitizeExportBaseName,
 } from "@/lib/adhoc-export";
-import { hasSplitVariableStatsForVariable } from "@/lib/analysis-bridge";
+import {
+  getStackedBarSegmentCount,
+  hasSplitVariableStatsForVariable,
+  transformToRechartsPieData,
+} from "@/lib/analysis-bridge";
 import { determineChartSelection } from "@/lib/chart-selection";
+import { resolveSingleSeriesThemeChartColors, resolveThemePaletteForCount } from "@/lib/organization-theme";
 import { getVariableLabel } from "@/lib/variable-helpers";
 import { type DatasetVariableWithAttributes } from "@/types/dataset-variable";
+import { type ThemeChartColors } from "@/types/organization";
 import { type AnalysisChartType, type StatsResponse } from "@/types/stats";
 import { Empty, EmptyContent, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "../ui/empty";
 import { ChartExportSurface } from "./chart-export-surface";
@@ -55,6 +61,7 @@ function ChartContent({
   stats,
   chartRef,
   percentageChartConfig,
+  chartColors,
   datasetId,
   isMultiResponseIndividual,
   countedValue,
@@ -64,6 +71,7 @@ function ChartContent({
   stats: StatsResponse;
   chartRef?: React.Ref<HTMLDivElement>;
   percentageChartConfig: ReturnType<typeof createPercentageChartConfig>;
+  chartColors?: ThemeChartColors;
   datasetId?: string;
   isMultiResponseIndividual: boolean;
   countedValue: number;
@@ -71,7 +79,13 @@ function ChartContent({
   switch (chartType) {
     case "bar":
       return (
-        <BarChartContent variable={variable} stats={stats} chartRef={chartRef} chartConfig={percentageChartConfig} />
+        <BarChartContent
+          variable={variable}
+          stats={stats}
+          chartRef={chartRef}
+          chartConfig={percentageChartConfig}
+          chartColors={chartColors}
+        />
       );
     case "horizontalBar":
       return (
@@ -80,6 +94,7 @@ function ChartContent({
           stats={stats}
           chartRef={chartRef}
           chartConfig={percentageChartConfig}
+          chartColors={chartColors}
           isMultiResponseIndividual={isMultiResponseIndividual}
           countedValue={countedValue}
         />
@@ -90,16 +105,17 @@ function ChartContent({
           variable={variable}
           stats={stats}
           ref={chartRef}
+          chartColors={chartColors}
           isMultiResponseIndividual={isMultiResponseIndividual}
           countedValue={countedValue}
         />
       );
     case "pie":
-      return <PieChartContent variable={variable} stats={stats} chartRef={chartRef} />;
+      return <PieChartContent variable={variable} stats={stats} chartRef={chartRef} chartColors={chartColors} />;
     case "metrics":
       return <MetricsCards variable={variable} stats={stats} />;
     case "meanBar":
-      return <MeanBarAdhoc variable={variable} stats={stats} ref={chartRef} />;
+      return <MeanBarAdhoc variable={variable} stats={stats} ref={chartRef} chartColors={chartColors} />;
     case "textExplorer":
       return <TextExplorerAdhoc variable={variable} datasetId={datasetId} />;
     default:
@@ -174,8 +190,27 @@ export function AdhocChart({
       }),
     [datasetId, datasetName, locale, splitVariableLabel, t]
   );
-  const fallbackChartColors = useMemo(() => resolveTheme(activeTheme).theme.chartColors, [activeTheme, resolveTheme]);
+  const resolvedTheme = useMemo(() => resolveTheme(activeTheme).theme, [activeTheme, resolveTheme]);
+  const fallbackChartColors = resolvedTheme.chartColors;
   const exportBaseName = useMemo(() => sanitizeExportBaseName(variable.name), [variable.name]);
+  const chartColors = useMemo(() => {
+    switch (actualSelectedChartType) {
+      case "bar":
+      case "horizontalBar":
+      case "meanBar":
+        return resolveSingleSeriesThemeChartColors(resolvedTheme);
+      case "pie": {
+        const categoryCount = Math.max(1, Math.min(6, transformToRechartsPieData(variable, stats).length));
+        return resolveThemePaletteForCount(resolvedTheme, categoryCount);
+      }
+      case "horizontalStackedBar": {
+        const segmentCount = Math.max(1, Math.min(6, getStackedBarSegmentCount(variable, stats)));
+        return resolveThemePaletteForCount(resolvedTheme, segmentCount);
+      }
+      default:
+        return undefined;
+    }
+  }, [actualSelectedChartType, resolvedTheme, stats, variable]);
 
   const handlePowerPointExport = useCallback(async () => {
     if (!datasetId || actualSelectedChartType === "textExplorer") {
@@ -287,6 +322,7 @@ export function AdhocChart({
       stats={stats}
       chartRef={displayRef}
       percentageChartConfig={percentageChartConfig}
+      chartColors={chartColors}
       datasetId={datasetId}
       isMultiResponseIndividual={isMultiResponseIndividual}
       countedValue={countedValue}
@@ -299,6 +335,7 @@ export function AdhocChart({
       variable={variable}
       stats={stats}
       percentageChartConfig={percentageChartConfig}
+      chartColors={chartColors}
       datasetId={datasetId}
       isMultiResponseIndividual={isMultiResponseIndividual}
       countedValue={countedValue}

--- a/apps/web/src/components/chart/adhoc-chart.tsx
+++ b/apps/web/src/components/chart/adhoc-chart.tsx
@@ -191,7 +191,6 @@ export function AdhocChart({
     [datasetId, datasetName, locale, splitVariableLabel, t]
   );
   const resolvedTheme = useMemo(() => resolveTheme(activeTheme).theme, [activeTheme, resolveTheme]);
-  const fallbackChartColors = resolvedTheme.chartColors;
   const exportBaseName = useMemo(() => sanitizeExportBaseName(variable.name), [variable.name]);
   const chartColors = useMemo(() => {
     switch (actualSelectedChartType) {
@@ -211,6 +210,7 @@ export function AdhocChart({
         return undefined;
     }
   }, [actualSelectedChartType, resolvedTheme, stats, variable]);
+  const fallbackChartColors = chartColors ?? resolvedTheme.chartColors;
 
   const handlePowerPointExport = useCallback(async () => {
     if (!datasetId || actualSelectedChartType === "textExplorer") {

--- a/apps/web/src/components/chart/chart-shared.tsx
+++ b/apps/web/src/components/chart/chart-shared.tsx
@@ -20,6 +20,7 @@ import {
 import { CHART_Y_AXIS_WIDTH, PERCENTAGE_CHART_DECIMALS, formatChartValue } from "@/lib/chart-constants";
 import { getPlotAreaHorizontalBorderCoordinates, getPlotAreaVerticalBorderCoordinates } from "@/lib/chart-grid";
 import { type DatasetVariable } from "@/types/dataset-variable";
+import { type ThemeChartColors } from "@/types/organization";
 import { type AnalysisChartType, type StatsResponse } from "@/types/stats";
 
 type PercentageChartConfigTranslations = {
@@ -61,15 +62,19 @@ export function BarChartContent({
   stats,
   chartRef,
   chartConfig,
+  chartColors,
 }: {
   variable: DatasetVariable;
   stats: StatsResponse;
   chartRef?: React.Ref<HTMLDivElement>;
   chartConfig: ChartConfig;
+  chartColors?: ThemeChartColors;
 }) {
+  const chartData = transformToRechartsBarData(variable, stats);
+
   return (
-    <ChartContainer config={chartConfig} ref={chartRef} data-export-filename={variable.name}>
-      <BarChart accessibilityLayer data={transformToRechartsBarData(variable, stats)}>
+    <ChartContainer config={chartConfig} chartColors={chartColors} ref={chartRef} data-export-filename={variable.name}>
+      <BarChart accessibilityLayer data={chartData}>
         <CartesianGrid vertical verticalCoordinatesGenerator={getPlotAreaVerticalBorderCoordinates} />
         <XAxis dataKey="label" tickLine={false} tickMargin={10} axisLine={false} fontSize={12} />
         <ChartTooltip cursor={false} content={<ChartTooltipContent hideLabel />} />
@@ -83,10 +88,14 @@ export function BarChartContent({
           tickFormatter={(value) => `${value}%`}
         />
         <Bar dataKey="percentage" fill="var(--color-percentage)">
+          {chartData.map((entry, index) => (
+            <Cell key={`${entry.label}-${index}`} fill={`var(--chart-${(index % 6) + 1})`} />
+          ))}
           <LabelList
             dataKey="percentage"
             position="top"
             fontSize={12}
+            fill="#808080"
             formatter={(value: unknown) => `${formatChartValue(Number(value), PERCENTAGE_CHART_DECIMALS)}%`}
           />
         </Bar>
@@ -100,6 +109,7 @@ export function HorizontalBarChartContent({
   stats,
   chartRef,
   chartConfig,
+  chartColors,
   isMultiResponseIndividual = false,
   countedValue = 1,
 }: {
@@ -107,6 +117,7 @@ export function HorizontalBarChartContent({
   stats: StatsResponse;
   chartRef?: React.Ref<HTMLDivElement>;
   chartConfig: ChartConfig;
+  chartColors?: ThemeChartColors;
   isMultiResponseIndividual?: boolean;
   countedValue?: number;
 }) {
@@ -120,7 +131,7 @@ export function HorizontalBarChartContent({
     : transformToRechartsBarData(variable, stats);
 
   return (
-    <ChartContainer config={chartConfig} ref={chartRef} data-export-filename={variable.name}>
+    <ChartContainer config={chartConfig} chartColors={chartColors} ref={chartRef} data-export-filename={variable.name}>
       <BarChart layout="vertical" margin={{ left: 0 }} barCategoryGap={1} accessibilityLayer data={chartData}>
         <CartesianGrid vertical horizontal horizontalCoordinatesGenerator={getPlotAreaHorizontalBorderCoordinates} />
         <XAxis
@@ -145,10 +156,14 @@ export function HorizontalBarChartContent({
           hide={isMultiResponseIndividual}
         />
         <Bar dataKey="percentage" fill="var(--color-percentage)">
+          {chartData.map((entry, index) => (
+            <Cell key={`${entry.label}-${index}`} fill={`var(--chart-${(index % 6) + 1})`} />
+          ))}
           <LabelList
             dataKey="percentage"
             position="right"
             fontSize={12}
+            fill="#808080"
             formatter={(value: unknown) => `${formatChartValue(Number(value), PERCENTAGE_CHART_DECIMALS)}%`}
           />
         </Bar>
@@ -162,10 +177,12 @@ export function PieChartContent({
   variable,
   stats,
   chartRef,
+  chartColors,
 }: {
   variable: DatasetVariable;
   stats: StatsResponse;
   chartRef?: React.Ref<HTMLDivElement>;
+  chartColors?: ThemeChartColors;
 }) {
   const pieData = transformToRechartsPieData(variable, stats);
   const pieChartConfig: ChartConfig = {};
@@ -189,7 +206,7 @@ export function PieChartContent({
   );
 
   return (
-    <ChartContainer config={pieChartConfig} ref={chartRef} data-export-filename={variable.name}>
+    <ChartContainer config={pieChartConfig} chartColors={chartColors} ref={chartRef} data-export-filename={variable.name}>
       <PieChart>
         <ChartTooltip cursor={false} content={<ChartTooltipContent nameKey="label" />} />
         <Pie data={pieData} dataKey="percentage" nameKey="label" startAngle={90} endAngle={-270}>

--- a/apps/web/src/components/chart/horizontal-stacked-bar-adhoc.tsx
+++ b/apps/web/src/components/chart/horizontal-stacked-bar-adhoc.tsx
@@ -19,6 +19,7 @@ import { PERCENTAGE_CHART_DECIMALS, formatChartValue } from "@/lib/chart-constan
 import { getPlotAreaHorizontalBorderCoordinates } from "@/lib/chart-grid";
 import { getVariableLabel } from "@/lib/variable-helpers";
 import { type DatasetVariable } from "@/types/dataset-variable";
+import { type ThemeChartColors } from "@/types/organization";
 import { type StatsResponse } from "@/types/stats";
 import {
   type HorizontalStackedBarModel,
@@ -29,6 +30,7 @@ import {
 type HorizontalStackedBarAdhocProps = {
   variable: DatasetVariable;
   stats: StatsResponse;
+  chartColors?: ThemeChartColors;
   isMultiResponseIndividual?: boolean;
   countedValue?: number;
 } & React.HTMLAttributes<HTMLDivElement>;
@@ -75,16 +77,18 @@ function HorizontalStackedBarChart({
   chartRef,
   exportFilename,
   hideLegend = false,
+  chartColors,
   tooltipContent,
 }: {
   model: HorizontalStackedBarModel;
   chartRef?: React.Ref<HTMLDivElement>;
   exportFilename: string;
   hideLegend?: boolean;
+  chartColors?: ThemeChartColors;
   tooltipContent?: React.ReactElement;
 }) {
   return (
-    <ChartContainer config={model.chartConfig} ref={chartRef} data-export-filename={exportFilename}>
+    <ChartContainer config={model.chartConfig} chartColors={chartColors} ref={chartRef} data-export-filename={exportFilename}>
       <BarChart layout="vertical" margin={{ left: 0 }} accessibilityLayer data={model.chartData}>
         <CartesianGrid vertical horizontal horizontalCoordinatesGenerator={getPlotAreaHorizontalBorderCoordinates} />
         <XAxis
@@ -124,7 +128,7 @@ function HorizontalStackedBarChart({
 }
 
 export const HorizontalStackedBarAdhoc = forwardRef<HTMLDivElement, HorizontalStackedBarAdhocProps>(
-  ({ variable, stats, isMultiResponseIndividual = false, countedValue = 1 }, ref) => {
+  ({ variable, stats, chartColors, isMultiResponseIndividual = false, countedValue = 1 }, ref) => {
     const hasSplitVariable = hasSplitVariableStatsForVariable(stats, variable.name);
 
     if (hasSplitVariable) {
@@ -137,6 +141,7 @@ export const HorizontalStackedBarAdhoc = forwardRef<HTMLDivElement, HorizontalSt
       return (
         <HorizontalStackedBarChart
           model={model}
+          chartColors={chartColors}
           chartRef={ref}
           exportFilename={variable.name}
           hideLegend={isMultiResponseIndividual}
@@ -148,7 +153,7 @@ export const HorizontalStackedBarAdhoc = forwardRef<HTMLDivElement, HorizontalSt
     const stackedData = transformToRechartsStackedBarData(variable, stats);
     const model = createSingleHorizontalStackedBarModel(getVariableLabel(variable), stackedData);
 
-    return <HorizontalStackedBarChart model={model} chartRef={ref} exportFilename={variable.name} />;
+    return <HorizontalStackedBarChart model={model} chartColors={chartColors} chartRef={ref} exportFilename={variable.name} />;
   }
 );
 

--- a/apps/web/src/components/chart/mean-bar-adhoc.tsx
+++ b/apps/web/src/components/chart/mean-bar-adhoc.tsx
@@ -2,20 +2,22 @@
 
 import { useTranslations } from "next-intl";
 import { forwardRef } from "react";
-import { Bar, BarChart, CartesianGrid, LabelList, XAxis, YAxis } from "recharts";
+import { Bar, BarChart, CartesianGrid, Cell, LabelList, XAxis, YAxis } from "recharts";
 import { type ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
 import { extractVariableStats } from "@/lib/analysis-bridge";
 import { CHART_Y_AXIS_WIDTH, MEAN_BAR_DECIMALS, formatChartValue } from "@/lib/chart-constants";
 import { getPlotAreaHorizontalBorderCoordinates } from "@/lib/chart-grid";
 import { type DatasetVariableWithAttributes } from "@/types/dataset-variable";
+import { type ThemeChartColors } from "@/types/organization";
 import { type StatsResponse } from "@/types/stats";
 
 type MeanBarAdhocProps = {
   variable: DatasetVariableWithAttributes;
   stats: StatsResponse;
+  chartColors?: ThemeChartColors;
 } & React.HTMLAttributes<HTMLDivElement>;
 
-export const MeanBarAdhoc = forwardRef<HTMLDivElement, MeanBarAdhocProps>(({ variable, stats }, ref) => {
+export const MeanBarAdhoc = forwardRef<HTMLDivElement, MeanBarAdhocProps>(({ variable, stats, chartColors }, ref) => {
   const t = useTranslations("chartMetricsCard");
   const variableStats = extractVariableStats(variable, stats);
   if (!variableStats) {
@@ -45,7 +47,7 @@ export const MeanBarAdhoc = forwardRef<HTMLDivElement, MeanBarAdhocProps>(({ var
   } satisfies ChartConfig;
 
   return (
-    <ChartContainer config={chartConfig} ref={ref} data-export-filename={variable.name}>
+    <ChartContainer config={chartConfig} chartColors={chartColors} ref={ref} data-export-filename={variable.name}>
       <BarChart layout="vertical" margin={{ left: 0 }} barCategoryGap={1} accessibilityLayer data={chartData}>
         <CartesianGrid vertical horizontal horizontalCoordinatesGenerator={getPlotAreaHorizontalBorderCoordinates} />
         <XAxis
@@ -67,9 +69,13 @@ export const MeanBarAdhoc = forwardRef<HTMLDivElement, MeanBarAdhocProps>(({ var
           width={CHART_Y_AXIS_WIDTH}
         />
         <Bar dataKey="value" fill="var(--color-value)">
+          {chartData.map((entry, index) => (
+            <Cell key={`${entry.label}-${index}`} fill={`var(--chart-${(index % 6) + 1})`} />
+          ))}
           <LabelList
             dataKey="value"
             position="right"
+            fill="#808080"
             formatter={(value: unknown) => `${formatChartValue(Number(value), MEAN_BAR_DECIMALS)}`}
           />
         </Bar>

--- a/apps/web/src/components/chart/multi-response-chart.tsx
+++ b/apps/web/src/components/chart/multi-response-chart.tsx
@@ -2,7 +2,7 @@
 
 import { useLocale, useTranslations } from "next-intl";
 import { useCallback, useMemo } from "react";
-import { Bar, BarChart, CartesianGrid, LabelList, XAxis, YAxis } from "recharts";
+import { Bar, BarChart, CartesianGrid, Cell, LabelList, XAxis, YAxis } from "recharts";
 import { toast } from "sonner";
 import { useThemeConfig } from "@/components/active-theme";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
@@ -18,9 +18,11 @@ import {
   sanitizeExportBaseName,
 } from "@/lib/adhoc-export";
 import { transformToMultiResponseData } from "@/lib/analysis-bridge";
+import { resolveSingleSeriesThemeChartColors } from "@/lib/organization-theme";
 import { CHART_Y_AXIS_WIDTH, PERCENTAGE_CHART_DECIMALS, formatChartValue } from "@/lib/chart-constants";
 import { getPlotAreaHorizontalBorderCoordinates } from "@/lib/chart-grid";
 import { type DatasetVariableWithAttributes } from "@/types/dataset-variable";
+import { type ThemeChartColors } from "@/types/organization";
 import { type StatsResponse } from "@/types/stats";
 import { ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent } from "../ui/chart";
 import { ChartExportMenu } from "./chart-export-menu";
@@ -38,17 +40,19 @@ type MultiResponseChartProps = {
 
 function MultiResponseChartContent({
   chartConfig,
+  chartColors,
   chartData,
   chartRef,
   fileName,
 }: {
   chartConfig: ChartConfig;
+  chartColors?: ThemeChartColors;
   chartData: ReturnType<typeof transformToMultiResponseData>;
   chartRef?: React.Ref<HTMLDivElement>;
   fileName: string;
 }) {
   return (
-    <ChartContainer config={chartConfig} ref={chartRef} data-export-filename={fileName}>
+    <ChartContainer config={chartConfig} chartColors={chartColors} ref={chartRef} data-export-filename={fileName}>
       <BarChart
         layout="vertical"
         margin={{
@@ -79,10 +83,14 @@ function MultiResponseChartContent({
           width={CHART_Y_AXIS_WIDTH}
         />
         <Bar dataKey="percentage" fill="var(--color-percentage)">
+          {chartData.map((entry, index) => (
+            <Cell key={`${entry.label}-${index}`} fill={`var(--chart-${(index % 6) + 1})`} />
+          ))}
           <LabelList
             dataKey="percentage"
             position="right"
             fontSize={12}
+            fill="#808080"
             formatter={(value: unknown) => `${formatChartValue(Number(value), PERCENTAGE_CHART_DECIMALS)}%`}
           />
         </Bar>
@@ -137,7 +145,9 @@ export function MultiResponseChart({
       }),
     [datasetName, locale, tAdhoc]
   );
-  const fallbackChartColors = useMemo(() => resolveTheme(activeTheme).theme.chartColors, [activeTheme, resolveTheme]);
+  const resolvedTheme = useMemo(() => resolveTheme(activeTheme).theme, [activeTheme, resolveTheme]);
+  const fallbackChartColors = resolvedTheme.chartColors;
+  const chartColors = useMemo(() => resolveSingleSeriesThemeChartColors(resolvedTheme), [resolvedTheme]);
 
   const handlePowerPointExport = useCallback(async () => {
     try {
@@ -215,7 +225,12 @@ export function MultiResponseChart({
   return (
     <Card className="shadow-xs" data-testid="multi-response-chart" {...props}>
       <ChartExportSurface exportRef={exportRef} fileName={exportBaseName} isRendering={isExportRendering}>
-        <MultiResponseChartContent chartConfig={chartConfig} chartData={chartData} fileName={exportBaseName} />
+        <MultiResponseChartContent
+          chartConfig={chartConfig}
+          chartColors={chartColors}
+          chartData={chartData}
+          fileName={exportBaseName}
+        />
       </ChartExportSurface>
       <CardHeader>
         <CardTitle>{variablesetName}</CardTitle>
@@ -224,6 +239,7 @@ export function MultiResponseChart({
       <CardContent>
         <MultiResponseChartContent
           chartConfig={chartConfig}
+          chartColors={chartColors}
           chartData={chartData}
           chartRef={displayRef}
           fileName={exportBaseName}

--- a/apps/web/src/components/ui/chart.tsx
+++ b/apps/web/src/components/ui/chart.tsx
@@ -61,6 +61,13 @@ function ChartContainer({
 }) {
   const uniqueId = React.useId()
   const chartId = `chart-${id ?? uniqueId.replace(/:/g, "")}`
+  const chartVariables = chartColors
+    ? (Object.fromEntries(Object.entries(chartColors).map(([key, value]) => [`--${key}`, value])) as React.CSSProperties)
+    : undefined
+  const mergedStyle = {
+    ...chartVariables,
+    ...props.style,
+  } satisfies React.CSSProperties
 
   return (
     <ChartContext.Provider value={{ config }}>
@@ -71,13 +78,7 @@ function ChartContainer({
           "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-surface]:outline-hidden",
           className
         )}
-        style={
-          chartColors
-            ? Object.fromEntries(
-                Object.entries(chartColors).map(([key, value]) => [`--${key}`, value])
-              ) as React.CSSProperties
-            : undefined
-        }
+        style={mergedStyle}
         {...props}
       >
         <ChartStyle id={chartId} config={config} />

--- a/apps/web/src/components/ui/chart.tsx
+++ b/apps/web/src/components/ui/chart.tsx
@@ -5,6 +5,7 @@ import * as RechartsPrimitive from "recharts"
 import type { TooltipValueType } from "recharts"
 
 import { cn } from "@/lib/utils"
+import type { ThemeChartColors } from "@/types/organization"
 
 // Format: { THEME_NAME: CSS_SELECTOR }
 const THEMES = { light: "", dark: ".dark" } as const
@@ -44,10 +45,12 @@ function ChartContainer({
   className,
   children,
   config,
+  chartColors,
   initialDimension = INITIAL_DIMENSION,
   ...props
 }: React.ComponentProps<"div"> & {
   config: ChartConfig
+  chartColors?: ThemeChartColors
   children: React.ComponentProps<
     typeof RechartsPrimitive.ResponsiveContainer
   >["children"]
@@ -68,6 +71,13 @@ function ChartContainer({
           "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-surface]:outline-hidden",
           className
         )}
+        style={
+          chartColors
+            ? Object.fromEntries(
+                Object.entries(chartColors).map(([key, value]) => [`--${key}`, value])
+              ) as React.CSSProperties
+            : undefined
+        }
         {...props}
       >
         <ChartStyle id={chartId} config={config} />

--- a/apps/web/src/context/organization-theme-context.tsx
+++ b/apps/web/src/context/organization-theme-context.tsx
@@ -2,7 +2,7 @@
 
 import { ReactNode, createContext, useContext, useMemo } from "react";
 import { useAppContext } from "@/context/app-context";
-import { sanitizeThemeChartColors } from "@/lib/organization-theme";
+import { withResolvedThemePalettes } from "@/lib/organization-theme";
 import { type Organization, type ThemeItem } from "@/types/organization";
 
 // Default themes that are always available
@@ -142,13 +142,12 @@ export function OrganizationThemeProvider({ children }: { children: ReactNode })
   const availableThemes = useMemo(() => {
     const organizationThemes = organizationWithSettings?.settings?.themes || [];
     const sanitizedOrganizationThemes = organizationThemes.map((theme: ThemeItem) => ({
-      ...theme,
-      chartColors: sanitizeThemeChartColors(theme.chartColors),
+      ...withResolvedThemePalettes(theme),
       name: theme.name
         .replace(/\s+/g, "-") // Replace spaces with hyphens
         .replace(/[^A-Za-z0-9\-_]/g, ""), // Remove any characters that aren't A-Za-z0-9, -, or _
     }));
-    return [...DEFAULT_THEMES, ...sanitizedOrganizationThemes];
+    return [...DEFAULT_THEMES.map(withResolvedThemePalettes), ...sanitizedOrganizationThemes];
   }, [organizationWithSettings?.settings?.themes]);
 
   const getThemeByName = (name: string): ThemeItem | null => {
@@ -156,12 +155,15 @@ export function OrganizationThemeProvider({ children }: { children: ReactNode })
     if (foundTheme) return foundTheme;
 
     const colorTheme = COLOR_THEME_MAPPINGS[name];
-    return colorTheme !== undefined ? colorTheme : null;
+    return colorTheme !== undefined ? withResolvedThemePalettes(colorTheme) : null;
   };
 
-  const getDefaultThemes = () => DEFAULT_THEMES;
+  const getDefaultThemes = () => DEFAULT_THEMES.map(withResolvedThemePalettes);
 
-  const getColorThemes = () => COLOR_THEME_MAPPINGS;
+  const getColorThemes = () =>
+    Object.fromEntries(
+      Object.entries(COLOR_THEME_MAPPINGS).map(([key, theme]) => [key, withResolvedThemePalettes(theme)])
+    );
 
   const resolveTheme = (activeThemeName: string) => {
     const sanitizedActiveThemeName = activeThemeName
@@ -177,8 +179,7 @@ export function OrganizationThemeProvider({ children }: { children: ReactNode })
     if (orgTheme) {
       return {
         theme: {
-          ...orgTheme,
-          chartColors: sanitizeThemeChartColors(orgTheme.chartColors),
+          ...withResolvedThemePalettes(orgTheme),
           name: orgTheme.name.replace(/\s+/g, "-").replace(/[^A-Za-z0-9\-_]/g, ""),
         },
         isOrganizationTheme: true,
@@ -191,18 +192,18 @@ export function OrganizationThemeProvider({ children }: { children: ReactNode })
     );
 
     if (defaultTheme) {
-      return { theme: defaultTheme, isOrganizationTheme: false };
+      return { theme: withResolvedThemePalettes(defaultTheme), isOrganizationTheme: false };
     }
 
     // Check color theme mappings
     const colorTheme = COLOR_THEME_MAPPINGS[sanitizedActiveThemeName.toLowerCase()];
     if (colorTheme) {
-      return { theme: colorTheme, isOrganizationTheme: false };
+      return { theme: withResolvedThemePalettes(colorTheme), isOrganizationTheme: false };
     }
 
     // Fallback to default theme
     return {
-      theme: DEFAULT_THEMES[0]!,
+      theme: withResolvedThemePalettes(DEFAULT_THEMES[0]!),
       isOrganizationTheme: false,
     };
   };

--- a/apps/web/src/lib/adhoc-export.test.ts
+++ b/apps/web/src/lib/adhoc-export.test.ts
@@ -310,6 +310,40 @@ describe("adhoc export helpers", () => {
     assert.deepStrictEqual(result, ["#abcdef", "#abcdef", "#abcdef", "#abcdef", "#abcdef", "#abcdef"]);
   });
 
+  test("getComputedExportPalette resolves the nearest chart ancestor for descendant nodes", () => {
+    const paletteByVariable: Record<string, string> = {
+      "var(--chart-1)": "rgb(171, 205, 239)",
+      "var(--chart-2)": "rgb(171, 205, 239)",
+      "var(--chart-3)": "rgb(171, 205, 239)",
+      "var(--chart-4)": "rgb(171, 205, 239)",
+      "var(--chart-5)": "rgb(171, 205, 239)",
+      "var(--chart-6)": "rgb(171, 205, 239)",
+    };
+    const nearestChart = {
+      matches: (selector: string) => selector === "[data-slot='chart']",
+      querySelector: () => null,
+      appendChild() {},
+    } as unknown as HTMLElement;
+    const descendant = {
+      matches: () => false,
+      closest: (selector: string) => (selector === "[data-slot='chart']" ? nearestChart : null),
+      querySelector: () => null,
+      appendChild() {},
+    } as unknown as HTMLElement;
+
+    const result = getComputedExportPalette(descendant, undefined, {
+      createProbe: () =>
+        ({
+          style: { color: "", pointerEvents: "", position: "", visibility: "" },
+          remove() {},
+        }) as unknown as HTMLElement,
+      getComputedColor: (probe) => paletteByVariable[probe.style.color] ?? "",
+      resolveScope: (scopeElement) => scopeElement,
+    });
+
+    assert.deepStrictEqual(result, ["#abcdef", "#abcdef", "#abcdef", "#abcdef", "#abcdef", "#abcdef"]);
+  });
+
   test("createMultiResponseExcelExportPayload maps aggregate chart data", () => {
     const payload = createMultiResponseExcelExportPayload({
       excelLabels: {

--- a/apps/web/src/lib/adhoc-export.test.ts
+++ b/apps/web/src/lib/adhoc-export.test.ts
@@ -105,7 +105,8 @@ describe("adhoc export helpers", () => {
           remove() {},
         }) as unknown as HTMLElement,
       getComputedColor: (probe) => paletteByVariable[probe.style.color] ?? "",
-      resolveScope: () =>
+      resolveScope: (scopeElement) =>
+        scopeElement ??
         ({
           appendChild() {},
         }) as unknown as HTMLElement,
@@ -136,7 +137,8 @@ describe("adhoc export helpers", () => {
           remove() {},
         }) as unknown as HTMLElement,
       getComputedColor: (probe) => paletteByVariable[probe.style.color] ?? "",
-      resolveScope: () =>
+      resolveScope: (scopeElement) =>
+        scopeElement ??
         ({
           appendChild() {},
         }) as unknown as HTMLElement,
@@ -163,7 +165,8 @@ describe("adhoc export helpers", () => {
           remove() {},
         }) as unknown as HTMLElement,
       getComputedColor: () => "not-a-color",
-      resolveScope: () =>
+      resolveScope: (scopeElement) =>
+        scopeElement ??
         ({
           appendChild() {},
         }) as unknown as HTMLElement,
@@ -277,6 +280,34 @@ describe("adhoc export helpers", () => {
       throw new Error("Expected multiResponse chart kind");
     }
     assert.deepStrictEqual(payload.chart.points, [{ label: "Awareness", value: 60, color: "#123456" }]);
+  });
+
+  test("getComputedExportPalette prefers chart-local CSS variables over theme container colors", () => {
+    const paletteByVariable: Record<string, string> = {
+      "var(--chart-1)": "rgb(171, 205, 239)",
+      "var(--chart-2)": "rgb(171, 205, 239)",
+      "var(--chart-3)": "rgb(171, 205, 239)",
+      "var(--chart-4)": "rgb(171, 205, 239)",
+      "var(--chart-5)": "rgb(171, 205, 239)",
+      "var(--chart-6)": "rgb(171, 205, 239)",
+    };
+    const scope = {
+      matches: (selector: string) => selector === "[data-slot='chart']",
+      querySelector: () => null,
+      appendChild() {},
+    } as unknown as HTMLElement;
+
+    const result = getComputedExportPalette(scope, undefined, {
+      createProbe: () =>
+        ({
+          style: { color: "", pointerEvents: "", position: "", visibility: "" },
+          remove() {},
+        }) as unknown as HTMLElement,
+      getComputedColor: (probe) => paletteByVariable[probe.style.color] ?? "",
+      resolveScope: (scopeElement) => scopeElement,
+    });
+
+    assert.deepStrictEqual(result, ["#abcdef", "#abcdef", "#abcdef", "#abcdef", "#abcdef", "#abcdef"]);
   });
 
   test("createMultiResponseExcelExportPayload maps aggregate chart data", () => {

--- a/apps/web/src/lib/adhoc-export.ts
+++ b/apps/web/src/lib/adhoc-export.ts
@@ -259,7 +259,8 @@ function createPaletteDomAdapter(): PaletteDomAdapter | null {
     createProbe: () => document.createElement("span"),
     getComputedColor: (probe) => getComputedStyle(probe).color,
     resolveScope: (scopeElement) =>
-      (scopeElement?.matches("[data-slot='chart']") ? scopeElement : scopeElement?.querySelector<HTMLElement>("[data-slot='chart']")) ??
+      (scopeElement?.matches("[data-slot='chart']") ? scopeElement : scopeElement?.closest<HTMLElement>("[data-slot='chart']")) ??
+      scopeElement?.querySelector<HTMLElement>("[data-slot='chart']") ??
       scopeElement?.closest<HTMLElement>(".theme-container") ??
       document.querySelector<HTMLElement>(".theme-container"),
     colorToHex: (color) => {

--- a/apps/web/src/lib/adhoc-export.ts
+++ b/apps/web/src/lib/adhoc-export.ts
@@ -259,7 +259,9 @@ function createPaletteDomAdapter(): PaletteDomAdapter | null {
     createProbe: () => document.createElement("span"),
     getComputedColor: (probe) => getComputedStyle(probe).color,
     resolveScope: (scopeElement) =>
-      scopeElement?.closest<HTMLElement>(".theme-container") ?? document.querySelector<HTMLElement>(".theme-container"),
+      (scopeElement?.matches("[data-slot='chart']") ? scopeElement : scopeElement?.querySelector<HTMLElement>("[data-slot='chart']")) ??
+      scopeElement?.closest<HTMLElement>(".theme-container") ??
+      document.querySelector<HTMLElement>(".theme-container"),
     colorToHex: (color) => {
       const normalizedHexColor = cssColorToHex(color);
       if (normalizedHexColor) {
@@ -316,13 +318,14 @@ function formatMetricValue(value?: number, decimals?: number) {
 function mapDistributionPoints(
   points: Array<{ label: string | number; percentage: number }>,
   palette: string[],
-  colorIndex: number = 0
+  uniformColor: boolean = true
 ) {
-  const color = palette[colorIndex] ?? DEFAULT_EXPORT_PALETTE[0];
-  return points.map((point) => ({
+  return points.map((point, index) => ({
     label: String(point.label),
     value: roundExportValue(point.percentage),
-    color,
+    color: uniformColor
+      ? (palette[0] ?? DEFAULT_EXPORT_PALETTE[0])
+      : (palette[index] ?? DEFAULT_EXPORT_PALETTE[index % DEFAULT_EXPORT_PALETTE.length]!),
   }));
 }
 
@@ -572,7 +575,7 @@ export function createVariableChartPowerPointExportPayload({
         palette,
         chart: {
           kind: "bar",
-          points: mapDistributionPoints(transformToRechartsBarData(variable, stats), palette),
+          points: mapDistributionPoints(transformToRechartsBarData(variable, stats), palette, true),
         },
       };
     }
@@ -588,7 +591,7 @@ export function createVariableChartPowerPointExportPayload({
         palette,
         chart: {
           kind: "horizontalBar",
-          points: mapDistributionPoints(points, palette),
+          points: mapDistributionPoints(points, palette, true),
         },
       };
     }
@@ -713,7 +716,7 @@ export function createMultiResponsePowerPointExportPayload({
     palette,
     chart: {
       kind: "multiResponse",
-      points: mapDistributionPoints(points, palette),
+      points: mapDistributionPoints(points, palette, true),
     },
   };
 }

--- a/apps/web/src/lib/analysis-bridge.test.ts
+++ b/apps/web/src/lib/analysis-bridge.test.ts
@@ -3,6 +3,7 @@ import { describe, test } from "node:test";
 import type { DatasetVariableWithAttributes } from "@/types/dataset-variable";
 import type { StatsResponse } from "@/types/stats";
 import {
+  getStackedBarSegmentCount,
   transformToMultiResponseData,
   transformToMultiResponseIndividualBarData,
   transformToSplitVariableStackedBarData,
@@ -107,6 +108,17 @@ describe("analysis-bridge transforms", () => {
     );
     assert.deepStrictEqual(result[0]?.segments.map((segment) => segment.label) ?? [], ["No", "Yes"]);
     assert.strictEqual(result[0]?.segments[1]?.value, 66.67);
+  });
+
+  test("getStackedBarSegmentCount returns the number of visible segments", () => {
+    const variable = createVariable();
+    const baseStats = createBaseStats("q1", [
+      { value: 0, counts: 10, percentages: 10 },
+      { value: 1, counts: 30, percentages: 30 },
+      { value: 2, counts: 60, percentages: 60 },
+    ]);
+
+    assert.strictEqual(getStackedBarSegmentCount(variable, baseStats), 3);
   });
 
   test("transformToMultiResponseData uses counted value and sorts by order index", () => {

--- a/apps/web/src/lib/analysis-bridge.ts
+++ b/apps/web/src/lib/analysis-bridge.ts
@@ -162,6 +162,20 @@ export function transformToRechartsStackedBarData(variableConfig: DatasetVariabl
   return rechartsData;
 }
 
+export function getStackedBarSegmentCount(variableConfig: DatasetVariable, statsData: StatsResponse) {
+  if (hasSplitVariableStatsForVariable(statsData, variableConfig.name)) {
+    const targetVariable = getStatsResponseItem(statsData, variableConfig.name);
+    if (!targetVariable || !isSplitVariableStats(targetVariable.stats)) {
+      return 0;
+    }
+
+    const firstCategory = Object.values(targetVariable.stats.categories)[0];
+    return firstCategory?.frequency_table.length ?? 0;
+  }
+
+  return transformToRechartsStackedBarData(variableConfig, statsData).length;
+}
+
 // New function for split variable stacked bar data
 export function transformToSplitVariableStackedBarData(variableConfig: DatasetVariable, statsData: StatsResponse) {
   const targetVariable = getStatsResponseItem(statsData, variableConfig.name);

--- a/apps/web/src/lib/organization-theme.test.ts
+++ b/apps/web/src/lib/organization-theme.test.ts
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
 import { describe, test } from "node:test";
 import { organizationSettingsSchema } from "@/types/organization";
-import { isValidThemeColor, sanitizeThemeChartColors } from "./organization-theme";
+import {
+  isValidThemeColor,
+  resolveSingleSeriesThemeChartColors,
+  resolveThemePaletteForCount,
+  sanitizeThemeChartColorPalettes,
+  sanitizeThemeChartColors,
+} from "./organization-theme";
 
 describe("organization theme validation", () => {
   test("accepts 6-digit hex chart colors", () => {
@@ -13,6 +19,16 @@ describe("organization theme validation", () => {
             "chart-1": "#3B82F6",
             "chart-2": "#ef4444",
           },
+          chartColorPalettes: {
+            "1": {
+              "chart-1": "#ABCDEF",
+            },
+            "3": {
+              "chart-1": "#112233",
+              "chart-2": "#445566",
+              "chart-3": "#778899",
+            },
+          },
         },
       ],
     });
@@ -20,6 +36,16 @@ describe("organization theme validation", () => {
     assert.deepStrictEqual(result?.themes?.[0]?.chartColors, {
       "chart-1": "#3b82f6",
       "chart-2": "#ef4444",
+    });
+    assert.deepStrictEqual(result?.themes?.[0]?.chartColorPalettes, {
+      "1": {
+        "chart-1": "#abcdef",
+      },
+      "3": {
+        "chart-1": "#112233",
+        "chart-2": "#445566",
+        "chart-3": "#778899",
+      },
     });
   });
 
@@ -46,6 +72,95 @@ describe("organization theme validation", () => {
       }),
       {
         "chart-1": "#3b82f6",
+      }
+    );
+  });
+
+  test("sanitizes persisted count palettes before rendering dynamic CSS", () => {
+    assert.deepStrictEqual(
+      sanitizeThemeChartColorPalettes({
+        "1": {
+          "chart-1": "#ABCDEF",
+        },
+        "2": {
+          "chart-1": "#123456",
+          "chart-2": "red;}</style><script>alert(1)</script><style>",
+        },
+      }),
+      {
+        "1": {
+          "chart-1": "#abcdef",
+        },
+      }
+    );
+  });
+
+  test("resolveThemePaletteForCount falls back to base chart colors", () => {
+    assert.deepStrictEqual(
+      resolveThemePaletteForCount(
+        {
+          chartColors: {
+            "chart-1": "#111111",
+            "chart-2": "#222222",
+            "chart-3": "#333333",
+          },
+        },
+        3
+      ),
+      {
+        "chart-1": "#111111",
+        "chart-2": "#222222",
+        "chart-3": "#333333",
+      }
+    );
+  });
+
+  test("resolveThemePaletteForCount merges explicit count palette with base colors", () => {
+    assert.deepStrictEqual(
+      resolveThemePaletteForCount(
+        {
+          chartColors: {
+            "chart-1": "#111111",
+            "chart-2": "#222222",
+            "chart-3": "#333333",
+          },
+          chartColorPalettes: {
+            "3": {
+              "chart-1": "#aaaaaa",
+              "chart-3": "#cccccc",
+            },
+          },
+        },
+        3
+      ),
+      {
+        "chart-1": "#aaaaaa",
+        "chart-2": "#222222",
+        "chart-3": "#cccccc",
+      }
+    );
+  });
+
+  test("resolveSingleSeriesThemeChartColors repeats the single-series color across all chart slots", () => {
+    assert.deepStrictEqual(
+      resolveSingleSeriesThemeChartColors({
+        chartColors: {
+          "chart-1": "#111111",
+          "chart-2": "#222222",
+        },
+        chartColorPalettes: {
+          "1": {
+            "chart-1": "#abcdef",
+          },
+        },
+      }),
+      {
+        "chart-1": "#abcdef",
+        "chart-2": "#abcdef",
+        "chart-3": "#abcdef",
+        "chart-4": "#abcdef",
+        "chart-5": "#abcdef",
+        "chart-6": "#abcdef",
       }
     );
   });

--- a/apps/web/src/lib/organization-theme.ts
+++ b/apps/web/src/lib/organization-theme.ts
@@ -1,10 +1,22 @@
 import {
   organizationThemeColorKeys,
   organizationThemeColorSchema,
+  organizationThemePaletteCountKeys,
+  themeChartColorPalettesSchema,
   themeChartColorsSchema,
 } from "@repo/database/schema";
 
-export { organizationThemeColorKeys, organizationThemeColorSchema, themeChartColorsSchema };
+import type { ThemeChartColorPalettes, ThemeChartColors, ThemeItem } from "@/types/organization";
+
+export {
+  organizationThemeColorKeys,
+  organizationThemeColorSchema,
+  organizationThemePaletteCountKeys,
+  themeChartColorPalettesSchema,
+  themeChartColorsSchema,
+};
+
+export const MAX_THEME_COLOR_COUNT = organizationThemeColorKeys.length;
 
 export function normalizeThemeColorInput(value: string) {
   return value.trim().toLowerCase();
@@ -30,4 +42,108 @@ export function sanitizeThemeChartColors(chartColors?: Record<string, string> | 
   }
 
   return Object.fromEntries(sanitizedEntries);
+}
+
+export function getThemeColorKey(index: number) {
+  return organizationThemeColorKeys[index - 1];
+}
+
+export function getThemeColorKeysForCount(count: number) {
+  const safeCount = Math.max(1, Math.min(MAX_THEME_COLOR_COUNT, count));
+  return organizationThemeColorKeys.slice(0, safeCount);
+}
+
+export function sanitizeThemeChartColorPalettes(chartColorPalettes?: ThemeChartColorPalettes | null) {
+  if (!chartColorPalettes) {
+    return undefined;
+  }
+
+  const sanitizedEntries = organizationThemePaletteCountKeys.flatMap((countKey) => {
+    const parsedPalette = themeChartColorsSchema.safeParse(chartColorPalettes[countKey]);
+    return parsedPalette.success ? [[countKey, parsedPalette.data] as const] : [];
+  });
+
+  if (sanitizedEntries.length === 0) {
+    return undefined;
+  }
+
+  return Object.fromEntries(sanitizedEntries) as ThemeChartColorPalettes;
+}
+
+export function createPaletteFromChartColors(chartColors?: ThemeChartColors | null, count: number = MAX_THEME_COLOR_COUNT) {
+  return getThemeColorKeysForCount(count).reduce<ThemeChartColors>((palette, colorKey) => {
+    const color = chartColors?.[colorKey];
+    if (color) {
+      palette[colorKey] = color;
+    }
+    return palette;
+  }, {});
+}
+
+export function repeatThemeColorAcrossPalette(color?: string | null) {
+  if (!color) {
+    return {};
+  }
+
+  return organizationThemeColorKeys.reduce<ThemeChartColors>((palette, colorKey) => {
+    palette[colorKey] = color;
+    return palette;
+  }, {});
+}
+
+export function getThemePaletteCountKey(count: number) {
+  if (!Number.isFinite(count)) {
+    return undefined;
+  }
+
+  const safeCount = Math.trunc(count);
+  if (safeCount < 1 || safeCount > MAX_THEME_COLOR_COUNT) {
+    return undefined;
+  }
+
+  return String(safeCount) as (typeof organizationThemePaletteCountKeys)[number];
+}
+
+export function resolveThemePaletteForCount(theme: Pick<ThemeItem, "chartColors" | "chartColorPalettes">, count: number) {
+  const countKey = getThemePaletteCountKey(count);
+  const paletteKeys = getThemeColorKeysForCount(count);
+  const configuredPalette = countKey ? sanitizeThemeChartColors(theme.chartColorPalettes?.[countKey]) : undefined;
+  const fallbackPalette = createPaletteFromChartColors(sanitizeThemeChartColors(theme.chartColors), paletteKeys.length);
+
+  return paletteKeys.reduce<ThemeChartColors>((resolvedPalette, colorKey, index) => {
+    const fallbackColorKey = organizationThemeColorKeys[index];
+    if (!fallbackColorKey) {
+      return resolvedPalette;
+    }
+
+    const color = configuredPalette?.[colorKey] ?? fallbackPalette[colorKey] ?? theme.chartColors?.[fallbackColorKey];
+    if (color) {
+      resolvedPalette[colorKey] = color;
+    }
+    return resolvedPalette;
+  }, {});
+}
+
+export function withResolvedThemePalettes(theme: ThemeItem): ThemeItem {
+  const chartColors = sanitizeThemeChartColors(theme.chartColors);
+  const configuredPalettes = sanitizeThemeChartColorPalettes(theme.chartColorPalettes);
+
+  const chartColorPalettes = organizationThemePaletteCountKeys.reduce<ThemeChartColorPalettes>((palettes, countKey) => {
+    const palette = resolveThemePaletteForCount({ chartColors, chartColorPalettes: configuredPalettes }, Number(countKey));
+    if (Object.keys(palette).length > 0) {
+      palettes[countKey] = palette;
+    }
+    return palettes;
+  }, {});
+
+  return {
+    ...theme,
+    chartColors,
+    chartColorPalettes: Object.keys(chartColorPalettes).length > 0 ? chartColorPalettes : undefined,
+  };
+}
+
+export function resolveSingleSeriesThemeChartColors(theme: Pick<ThemeItem, "chartColors" | "chartColorPalettes">) {
+  const singleSeriesPalette = resolveThemePaletteForCount(theme, 1);
+  return repeatThemeColorAcrossPalette(singleSeriesPalette["chart-1"] ?? theme.chartColors?.["chart-1"]);
 }

--- a/apps/web/src/lib/organization-theme.ts
+++ b/apps/web/src/lib/organization-theme.ts
@@ -70,6 +70,45 @@ export function sanitizeThemeChartColorPalettes(chartColorPalettes?: ThemeChartC
   return Object.fromEntries(sanitizedEntries) as ThemeChartColorPalettes;
 }
 
+function sanitizeThemePaletteColorValue(value?: string | null) {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const normalizedValue = normalizeThemeColorInput(value);
+  return isValidThemeColor(normalizedValue) ? normalizedValue : undefined;
+}
+
+export function sanitizeThemesPayload(themes: ThemeItem[], previousThemes?: ThemeItem[]) {
+  return themes.map((theme, index) => {
+    const previousTheme = previousThemes?.[index];
+    const sanitizedPalettes = organizationThemePaletteCountKeys.flatMap((countKey) => {
+      const currentPalette = theme.chartColorPalettes?.[countKey];
+      if (!currentPalette) {
+        return [];
+      }
+
+      const previousPalette = previousTheme?.chartColorPalettes?.[countKey];
+      const sanitizedPaletteEntries = organizationThemeColorKeys.flatMap((colorKey) => {
+        const sanitizedCurrentValue = sanitizeThemePaletteColorValue(currentPalette[colorKey]);
+        if (sanitizedCurrentValue) {
+          return [[colorKey, sanitizedCurrentValue] as const];
+        }
+
+        const sanitizedPreviousValue = sanitizeThemePaletteColorValue(previousPalette?.[colorKey]);
+        return sanitizedPreviousValue ? [[colorKey, sanitizedPreviousValue] as const] : [];
+      });
+
+      return sanitizedPaletteEntries.length > 0 ? [[countKey, Object.fromEntries(sanitizedPaletteEntries) as ThemeChartColors] as const] : [];
+    });
+
+    return {
+      ...theme,
+      chartColorPalettes: sanitizedPalettes.length > 0 ? (Object.fromEntries(sanitizedPalettes) as ThemeChartColorPalettes) : undefined,
+    };
+  });
+}
+
 export function createPaletteFromChartColors(chartColors?: ThemeChartColors | null, count: number = MAX_THEME_COLOR_COUNT) {
   return getThemeColorKeysForCount(count).reduce<ThemeChartColors>((palette, colorKey) => {
     const color = chartColors?.[colorKey];

--- a/apps/web/src/types/organization.ts
+++ b/apps/web/src/types/organization.ts
@@ -2,11 +2,14 @@ import {
   type CreateOrganizationData,
   type Organization,
   type OrganizationSettings,
+  type ThemeChartColorPalettes,
+  type ThemeChartColors,
   type ThemeItem,
   type UpdateOrganizationData,
   insertOrganizationSchema,
   organizationSettingsSchema,
   selectOrganizationSchema,
+  themeChartColorPalettesSchema,
   updateOrganizationSchema,
 } from "@repo/database/schema";
 
@@ -15,9 +18,12 @@ export {
   selectOrganizationSchema,
   updateOrganizationSchema,
   organizationSettingsSchema,
+  themeChartColorPalettesSchema,
   type OrganizationSettings,
   type CreateOrganizationData,
   type Organization,
+  type ThemeChartColorPalettes,
+  type ThemeChartColors,
   type UpdateOrganizationData,
   type ThemeItem,
 };

--- a/packages/database/src/schema/auth.ts
+++ b/packages/database/src/schema/auth.ts
@@ -16,9 +16,26 @@ import {
 import { createInsertSchema, createSelectSchema, createUpdateSchema } from "drizzle-zod";
 import { z } from "zod";
 
+export const organizationThemeColorKeys = [
+  "chart-1",
+  "chart-2",
+  "chart-3",
+  "chart-4",
+  "chart-5",
+  "chart-6",
+] as const;
+
+export const organizationThemePaletteCountKeys = ["1", "2", "3", "4", "5", "6"] as const;
+
+export type ThemeChartColors = Partial<Record<(typeof organizationThemeColorKeys)[number], string>>;
+export type ThemeChartColorPalettes = Partial<
+  Record<(typeof organizationThemePaletteCountKeys)[number], ThemeChartColors>
+>;
+
 export type ThemeItem = {
   name: string;
-  chartColors?: Record<string, string>;
+  chartColors?: ThemeChartColors;
+  chartColorPalettes?: ThemeChartColorPalettes;
 };
 
 export type OrganizationSettings = {
@@ -173,16 +190,6 @@ export const authSchema = {
 
 export type AuthUser = typeof user.$inferSelect;
 
-// Organization settings schemas
-export const organizationThemeColorKeys = [
-  "chart-1",
-  "chart-2",
-  "chart-3",
-  "chart-4",
-  "chart-5",
-  "chart-6",
-] as const;
-
 export const organizationThemeColorSchema = z
   .string()
   .trim()
@@ -202,9 +209,21 @@ export const themeChartColorsSchema = z
   })
   .strict();
 
+export const themeChartColorPalettesSchema = z
+  .object({
+    "1": themeChartColorsSchema.optional(),
+    "2": themeChartColorsSchema.optional(),
+    "3": themeChartColorsSchema.optional(),
+    "4": themeChartColorsSchema.optional(),
+    "5": themeChartColorsSchema.optional(),
+    "6": themeChartColorsSchema.optional(),
+  })
+  .strict();
+
 export const themeItemSchema = z.object({
   name: z.string(),
   chartColors: themeChartColorsSchema.optional(),
+  chartColorPalettes: themeChartColorPalettesSchema.optional(),
 });
 
 export const organizationSettingsSchema = z

--- a/packages/e2e-web/tests/adhoc-analysis-export-theme-colors.spec.ts
+++ b/packages/e2e-web/tests/adhoc-analysis-export-theme-colors.spec.ts
@@ -52,11 +52,11 @@ async function selectTheme(page: Page, themeName: string) {
   await expect.poll(() => page.evaluate(() => document.body.className)).toContain(`theme-${themeName.toLowerCase()}`);
 }
 
-async function readThemePalette(page: Page) {
+async function readChartPalette(page: Page) {
   return page.evaluate(() => {
-    const themeContainer = document.querySelector(".theme-container");
-    if (!(themeContainer instanceof HTMLElement)) {
-      throw new Error("Theme container not found");
+    const chartContainer = document.querySelector("[data-testid='chart-content-horizontalBar'] [data-slot='chart']");
+    if (!(chartContainer instanceof HTMLElement)) {
+      throw new Error("Chart container not found");
     }
 
     const canvas = document.createElement("canvas");
@@ -84,7 +84,7 @@ async function readThemePalette(page: Page) {
       probe.style.position = "absolute";
       probe.style.visibility = "hidden";
       probe.style.pointerEvents = "none";
-      themeContainer.appendChild(probe);
+      chartContainer.appendChild(probe);
 
       try {
         return toHex(getComputedStyle(probe).color);
@@ -168,10 +168,10 @@ test.describe("Adhoc Analysis - Export Theme Colors", () => {
     await selectDegreeVariable(page);
     await selectTheme(page, THEME_NAME);
 
-    const expectedPalette = await readThemePalette(page);
+    const expectedPalette = await readChartPalette(page);
     const expectedBarColor = await readRenderedBarColor(page);
 
-    expect(expectedPalette[0]).toBe(expectedBarColor);
+    expect(new Set(expectedPalette)).toEqual(new Set([expectedBarColor]));
     expect(colorChannelToHex(Number.parseInt(expectedBarColor.slice(1, 3), 16))).toBe(expectedBarColor.slice(1, 3));
 
     const excelPayload = await captureExportPayload(page, EXCEL_EXPORT_ROUTE, "Export as Excel");

--- a/packages/e2e-web/tests/admin-organizations.spec.ts
+++ b/packages/e2e-web/tests/admin-organizations.spec.ts
@@ -28,6 +28,7 @@ test.describe("Admin organizations", () => {
     await page.getByTestId("admin.organizations.new.form.slug").fill(newOrganization.slug);
     await page.getByTestId("theme-name-0").fill("CompanyTheme");
     await page.getByTestId("theme-color-0-chart-1").fill("#eeeeee");
+    await page.getByTestId("theme-palette-color-0-1-chart-1").fill("#123456");
 
     // Submit the form and wait for the response
     await page.getByTestId("admin.organizations.new.form.submit").click();
@@ -37,6 +38,7 @@ test.describe("Admin organizations", () => {
     await expect(page.getByTestId("admin.organizations.edit.page")).toBeVisible();
     await expect(page.getByTestId("theme-name-0")).toHaveValue("CompanyTheme");
     await expect(page.getByTestId("theme-color-0-chart-1")).toHaveValue("#eeeeee");
+    await expect(page.getByTestId("theme-palette-color-0-1-chart-1")).toHaveValue("#123456");
     await page.getByTestId("admin.organizations.edit.form.name").fill(editOrganization.name);
     await page.getByTestId("admin.organizations.edit.form.slug").fill(editOrganization.slug);
 


### PR DESCRIPTION
## Summary
- Add count-based organization chart palettes and editor controls
- Apply palette resolution to adhoc charts and exports
- Keep bar value labels in the original neutral style

## Testing
- make check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Charts now dynamically apply theme-based color palettes that adapt based on chart type and data complexity
  * Organization administrators can configure multiple color palettes for different chart scenarios
  * Enhanced theme system with improved support for pie charts, stacked bar charts, and other visualization types using adaptive coloring

<!-- end of auto-generated comment: release notes by coderabbit.ai -->