### PR TITLE
refactor destructive confirmations to alert dialog

### DIFF
--- a/apps/web/src/components/admin/dataset-editor/delete-dataset-variable-dialog.tsx
+++ b/apps/web/src/components/admin/dataset-editor/delete-dataset-variable-dialog.tsx
@@ -4,15 +4,18 @@ import { Trash } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 import { toast } from "sonner";
-import { Button } from "@/components/ui/button";
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
 
 interface DeleteDatasetVariableDialogProps {
   datasetVariableId: string;
@@ -45,46 +48,46 @@ export function DeleteDatasetVariableDialog({
   };
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <Button
-        variant="outline"
-        size="icon"
-        title={t("tableActions.delete")}
-        data-testid={`admin.dataset-variable.delete-${datasetVariableName}`}
-        onClick={(e) => {
-          e.preventDefault();
-          setOpen(true);
-        }}
-        className="cursor-pointer"
-        type="button">
-        <Trash className="h-4 w-4" />
-        <span className="sr-only">{t("tableActions.delete")}</span>
-      </Button>
-      <DialogContent className="sm:max-w-[425px]">
-        <DialogHeader>
-          <DialogTitle>{t("deleteDialog.title")}</DialogTitle>
-          <DialogDescription>{t("deleteDialog.description", { name: datasetVariableName })}</DialogDescription>
-        </DialogHeader>
-        <DialogFooter className="gap-2 sm:gap-0">
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger asChild>
+        <Button
+          variant="outline"
+          size="icon"
+          title={t("tableActions.delete")}
+          data-testid={`admin.dataset-variable.delete-${datasetVariableName}`}
+          className="cursor-pointer"
+          type="button">
+          <Trash className="h-4 w-4" />
+          <span className="sr-only">{t("tableActions.delete")}</span>
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent className="sm:max-w-[425px]">
+        <AlertDialogHeader>
+          <AlertDialogTitle>{t("deleteDialog.title")}</AlertDialogTitle>
+          <AlertDialogDescription>{t("deleteDialog.description", { name: datasetVariableName })}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter className="gap-2 sm:gap-0">
           <div className="flex w-full flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-            <Button
-              variant="outline"
+            <AlertDialogCancel
               onClick={() => setOpen(false)}
               disabled={isDeleting}
               className="w-full cursor-pointer sm:w-auto">
               {t("deleteDialog.cancel")}
-            </Button>
-            <Button
+            </AlertDialogCancel>
+            <AlertDialogAction
               data-testid={`admin.dataset-variable.delete-confirm-${datasetVariableName}`}
               variant="destructive"
-              onClick={handleDelete}
+              onClick={(event) => {
+                event.preventDefault();
+                void handleDelete();
+              }}
               disabled={isDeleting}
               className="w-full cursor-pointer sm:w-auto">
               {isDeleting ? t("deleteDialog.deleting") : t("deleteDialog.confirm")}
-            </Button>
+            </AlertDialogAction>
           </div>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 }

--- a/apps/web/src/components/admin/dataset-variableset/delete-variableset-dialog.tsx
+++ b/apps/web/src/components/admin/dataset-variableset/delete-variableset-dialog.tsx
@@ -5,15 +5,18 @@ import { useTranslations } from "next-intl";
 import { useState } from "react";
 import { toast } from "sonner";
 import { deleteVariableset } from "@/actions/dataset-variableset";
-import { Button } from "@/components/ui/button";
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
 
 interface DeleteVariablesetDialogProps {
   variablesetId: string;
@@ -42,47 +45,47 @@ export function DeleteVariablesetDialog({ variablesetId, variablesetName, onSucc
   };
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <Button
-        variant="outline"
-        size="icon"
-        title={t("deleteSet")}
-        onClick={(e) => {
-          e.preventDefault();
-          setOpen(true);
-        }}
-        className="cursor-pointer"
-        type="button"
-        data-testid="admin.dataset.variableset.delete.trigger">
-        <Trash className="h-4 w-4" />
-        <span className="sr-only">{t("deleteSet")}</span>
-      </Button>
-      <DialogContent className="sm:max-w-[425px]">
-        <DialogHeader>
-          <DialogTitle>{t("deleteDialog.title")}</DialogTitle>
-          <DialogDescription>{t("deleteDialog.description", { name: variablesetName })}</DialogDescription>
-        </DialogHeader>
-        <DialogFooter className="gap-2 sm:gap-0">
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger asChild>
+        <Button
+          variant="outline"
+          size="icon"
+          title={t("deleteSet")}
+          className="cursor-pointer"
+          type="button"
+          data-testid="admin.dataset.variableset.delete.trigger">
+          <Trash className="h-4 w-4" />
+          <span className="sr-only">{t("deleteSet")}</span>
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent className="sm:max-w-[425px]">
+        <AlertDialogHeader>
+          <AlertDialogTitle>{t("deleteDialog.title")}</AlertDialogTitle>
+          <AlertDialogDescription>{t("deleteDialog.description", { name: variablesetName })}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter className="gap-2 sm:gap-0">
           <div className="flex w-full flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-            <Button
-              variant="outline"
+            <AlertDialogCancel
               onClick={() => setOpen(false)}
               disabled={isDeleting}
               className="w-full cursor-pointer sm:w-auto"
               data-testid="admin.dataset.variableset.delete.cancel">
               {t("deleteDialog.cancel")}
-            </Button>
-            <Button
+            </AlertDialogCancel>
+            <AlertDialogAction
               variant="destructive"
-              onClick={handleDelete}
+              onClick={(event) => {
+                event.preventDefault();
+                void handleDelete();
+              }}
               disabled={isDeleting}
               className="w-full cursor-pointer sm:w-auto"
               data-testid="admin.dataset.variableset.delete.confirm">
               {isDeleting ? t("deleteDialog.deleting") : t("deleteDialog.confirm")}
-            </Button>
+            </AlertDialogAction>
           </div>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 }

--- a/apps/web/src/components/admin/dataset/delete-dataset-dialog.tsx
+++ b/apps/web/src/components/admin/dataset/delete-dataset-dialog.tsx
@@ -4,15 +4,18 @@ import { Trash } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 import { toast } from "sonner";
-import { Button } from "@/components/ui/button";
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
 
 interface DeleteDatasetDialogProps {
   datasetId: string;
@@ -41,44 +44,44 @@ export function DeleteDatasetDialog({ datasetId, datasetName, onDelete }: Delete
   };
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <Button
-        variant="outline"
-        size="icon"
-        title={t("tableActions.delete")}
-        onClick={(e) => {
-          e.preventDefault();
-          setOpen(true);
-        }}
-        className="cursor-pointer"
-        type="button">
-        <Trash className="h-4 w-4" />
-        <span className="sr-only">{t("tableActions.delete")}</span>
-      </Button>
-      <DialogContent className="sm:max-w-[425px]">
-        <DialogHeader>
-          <DialogTitle>{t("deleteDialog.title")}</DialogTitle>
-          <DialogDescription>{t("deleteDialog.description", { name: datasetName })}</DialogDescription>
-        </DialogHeader>
-        <DialogFooter className="gap-2 sm:gap-0">
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger asChild>
+        <Button
+          variant="outline"
+          size="icon"
+          title={t("tableActions.delete")}
+          className="cursor-pointer"
+          type="button">
+          <Trash className="h-4 w-4" />
+          <span className="sr-only">{t("tableActions.delete")}</span>
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent className="sm:max-w-[425px]">
+        <AlertDialogHeader>
+          <AlertDialogTitle>{t("deleteDialog.title")}</AlertDialogTitle>
+          <AlertDialogDescription>{t("deleteDialog.description", { name: datasetName })}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter className="gap-2 sm:gap-0">
           <div className="flex w-full flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-            <Button
-              variant="outline"
+            <AlertDialogCancel
               onClick={() => setOpen(false)}
               disabled={isDeleting}
               className="w-full cursor-pointer sm:w-auto">
               {t("deleteDialog.cancel")}
-            </Button>
-            <Button
+            </AlertDialogCancel>
+            <AlertDialogAction
               variant="destructive"
-              onClick={handleDelete}
+              onClick={(event) => {
+                event.preventDefault();
+                void handleDelete();
+              }}
               disabled={isDeleting}
               className="w-full cursor-pointer sm:w-auto">
               {isDeleting ? t("deleteDialog.deleting") : t("deleteDialog.confirm")}
-            </Button>
+            </AlertDialogAction>
           </div>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 }

--- a/apps/web/src/components/admin/organization-members/remove-member-dialog.tsx
+++ b/apps/web/src/components/admin/organization-members/remove-member-dialog.tsx
@@ -4,15 +4,18 @@ import { Trash } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 import { toast } from "sonner";
-import { Button } from "@/components/ui/button";
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
 
 interface RemoveMemberDialogProps {
   memberId: string;
@@ -40,46 +43,46 @@ export function RemoveMemberDialog({ memberId, username, onRemove }: RemoveMembe
   };
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <Button
-        variant="outline"
-        size="icon"
-        title={t("organizationMembers.removeDialog.deleteButton.title")}
-        onClick={(e) => {
-          e.preventDefault();
-          setOpen(true);
-        }}
-        className="cursor-pointer"
-        type="button">
-        <Trash className="h-4 w-4" />
-        <span className="sr-only">{t("organizationMembers.removeDialog.deleteButton.srText")}</span>
-      </Button>
-      <DialogContent className="sm:max-w-[425px]">
-        <DialogHeader>
-          <DialogTitle>{t("organizationMembers.removeDialog.title")}</DialogTitle>
-          <DialogDescription>{t("organizationMembers.removeDialog.description", { name: username })}</DialogDescription>
-        </DialogHeader>
-        <DialogFooter className="gap-2 sm:gap-0">
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger asChild>
+        <Button
+          variant="outline"
+          size="icon"
+          title={t("organizationMembers.removeDialog.deleteButton.title")}
+          className="cursor-pointer"
+          type="button">
+          <Trash className="h-4 w-4" />
+          <span className="sr-only">{t("organizationMembers.removeDialog.deleteButton.srText")}</span>
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent className="sm:max-w-[425px]">
+        <AlertDialogHeader>
+          <AlertDialogTitle>{t("organizationMembers.removeDialog.title")}</AlertDialogTitle>
+          <AlertDialogDescription>{t("organizationMembers.removeDialog.description", { name: username })}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter className="gap-2 sm:gap-0">
           <div className="flex w-full flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-            <Button
-              variant="outline"
+            <AlertDialogCancel
               onClick={() => setOpen(false)}
               disabled={isRemoving}
               className="w-full cursor-pointer sm:w-auto">
               {t("organizationMembers.removeDialog.cancel")}
-            </Button>
-            <Button
+            </AlertDialogCancel>
+            <AlertDialogAction
               variant="destructive"
-              onClick={handleRemove}
+              onClick={(event) => {
+                event.preventDefault();
+                void handleRemove();
+              }}
               disabled={isRemoving}
               className="w-full cursor-pointer sm:w-auto">
               {isRemoving
                 ? t("organizationMembers.removeDialog.deleting")
                 : t("organizationMembers.removeDialog.confirm")}
-            </Button>
+            </AlertDialogAction>
           </div>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 }

--- a/apps/web/src/components/admin/organization/delete-organization-dialog.tsx
+++ b/apps/web/src/components/admin/organization/delete-organization-dialog.tsx
@@ -4,15 +4,18 @@ import { Trash } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 import { toast } from "sonner";
-import { Button } from "@/components/ui/button";
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
 
 interface DeleteOrganizationDialogProps {
   organizationId: string;
@@ -44,46 +47,46 @@ export function DeleteOrganizationDialog({
   };
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <Button
-        variant="outline"
-        size="icon"
-        title={t("organization.deleteDialog.deleteButton.title")}
-        onClick={(e) => {
-          e.preventDefault();
-          setOpen(true);
-        }}
-        className="cursor-pointer"
-        type="button">
-        <Trash className="h-4 w-4" />
-        <span className="sr-only">{t("organization.deleteDialog.deleteButton.srText")}</span>
-      </Button>
-      <DialogContent className="sm:max-w-[425px]">
-        <DialogHeader>
-          <DialogTitle>{t("organization.deleteDialog.title")}</DialogTitle>
-          <DialogDescription>
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger asChild>
+        <Button
+          variant="outline"
+          size="icon"
+          title={t("organization.deleteDialog.deleteButton.title")}
+          className="cursor-pointer"
+          type="button">
+          <Trash className="h-4 w-4" />
+          <span className="sr-only">{t("organization.deleteDialog.deleteButton.srText")}</span>
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent className="sm:max-w-[425px]">
+        <AlertDialogHeader>
+          <AlertDialogTitle>{t("organization.deleteDialog.title")}</AlertDialogTitle>
+          <AlertDialogDescription>
             {t("organization.deleteDialog.description", { name: organizationName })}
-          </DialogDescription>
-        </DialogHeader>
-        <DialogFooter className="gap-2 sm:gap-0">
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter className="gap-2 sm:gap-0">
           <div className="flex w-full flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-            <Button
-              variant="outline"
+            <AlertDialogCancel
               onClick={() => setOpen(false)}
               disabled={isDeleting}
               className="w-full cursor-pointer sm:w-auto">
               {t("organization.deleteDialog.cancel")}
-            </Button>
-            <Button
+            </AlertDialogCancel>
+            <AlertDialogAction
               variant="destructive"
-              onClick={handleDelete}
+              onClick={(event) => {
+                event.preventDefault();
+                void handleDelete();
+              }}
               disabled={isDeleting}
               className="w-full cursor-pointer sm:w-auto">
               {isDeleting ? t("organization.deleteDialog.deleting") : t("organization.deleteDialog.confirm")}
-            </Button>
+            </AlertDialogAction>
           </div>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 }

--- a/apps/web/src/components/admin/project/delete-project-dialog.tsx
+++ b/apps/web/src/components/admin/project/delete-project-dialog.tsx
@@ -4,15 +4,18 @@ import { Trash } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 import { toast } from "sonner";
-import { Button } from "@/components/ui/button";
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
 
 type Props = {
   projectId: string;
@@ -41,35 +44,45 @@ export function DeleteProjectDialog({ projectId, projectName, onDelete }: Props)
   };
 
   return (
-    <Dialog open={isOpen} onOpenChange={setIsOpen}>
-      <Button
-        variant="outline"
-        size="icon"
-        onClick={() => setIsOpen(true)}
-        data-testid={`admin.projects.list.delete-${projectName?.toLowerCase().replace(/\s+/g, "-")}`}
-        title={t("deleteDialog.deleteButton.title")}
-        className="cursor-pointer">
-        <Trash className="h-4 w-4" />
-      </Button>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>{t("deleteDialog.title")}</DialogTitle>
-          <DialogDescription>
+    <AlertDialog open={isOpen} onOpenChange={setIsOpen}>
+      <AlertDialogTrigger asChild>
+        <Button
+          variant="outline"
+          size="icon"
+          data-testid={`admin.projects.list.delete-${projectName?.toLowerCase().replace(/\s+/g, "-")}`}
+          title={t("deleteDialog.deleteButton.title")}
+          className="cursor-pointer"
+          type="button">
+          <Trash className="h-4 w-4" />
+          <span className="sr-only">{t("deleteDialog.deleteButton.title")}</span>
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{t("deleteDialog.title")}</AlertDialogTitle>
+          <AlertDialogDescription>
             {t.rich("deleteDialog.description", {
               name: projectName,
               strong: (chunks: React.ReactNode) => <span className="font-semibold">{chunks}</span>,
             })}
-          </DialogDescription>
-        </DialogHeader>
-        <DialogFooter>
-          <Button variant="outline" onClick={() => setIsOpen(false)} disabled={isDeleting}>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={() => setIsOpen(false)} disabled={isDeleting}>
             {t("deleteDialog.cancel")}
-          </Button>
-          <Button variant="destructive" onClick={handleDelete} disabled={isDeleting} className="cursor-pointer">
+          </AlertDialogCancel>
+          <AlertDialogAction
+            variant="destructive"
+            onClick={(event) => {
+              event.preventDefault();
+              void handleDelete();
+            }}
+            disabled={isDeleting}
+            className="cursor-pointer">
             {isDeleting ? t("deleteDialog.deleting") : t("deleteDialog.confirm")}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 }

--- a/apps/web/src/components/admin/user/delete-user-dialog.tsx
+++ b/apps/web/src/components/admin/user/delete-user-dialog.tsx
@@ -4,15 +4,18 @@ import { Trash } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 import { toast } from "sonner";
-import { Button } from "@/components/ui/button";
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
 
 type Props = {
   userId: string;
@@ -41,47 +44,50 @@ export function DeleteUserDialog({ userId, userName, onDelete }: Props) {
   };
 
   return (
-    <Dialog open={isOpen} onOpenChange={setIsOpen}>
-      <Button
-        variant="outline"
-        size="icon"
-        onClick={() => setIsOpen(true)}
-        data-testid={`admin.users.list.delete-${userName?.toLowerCase().replace(/\s+/g, "-")}`}
-        title={t("deleteDialog.deleteButton.title")}
-        className="cursor-pointer"
-        type="button">
-        <Trash className="h-4 w-4" />
-        <span className="sr-only">{t("deleteDialog.deleteButton.srText")}</span>
-      </Button>
-      <DialogContent className="sm:max-w-[425px]">
-        <DialogHeader>
-          <DialogTitle>{t("deleteDialog.title")}</DialogTitle>
-          <DialogDescription>
+    <AlertDialog open={isOpen} onOpenChange={setIsOpen}>
+      <AlertDialogTrigger asChild>
+        <Button
+          variant="outline"
+          size="icon"
+          data-testid={`admin.users.list.delete-${userName?.toLowerCase().replace(/\s+/g, "-")}`}
+          title={t("deleteDialog.deleteButton.title")}
+          className="cursor-pointer"
+          type="button">
+          <Trash className="h-4 w-4" />
+          <span className="sr-only">{t("deleteDialog.deleteButton.srText")}</span>
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent className="sm:max-w-[425px]">
+        <AlertDialogHeader>
+          <AlertDialogTitle>{t("deleteDialog.title")}</AlertDialogTitle>
+          <AlertDialogDescription>
             {t.rich("deleteDialog.description", {
               name: userName,
               strong: (chunks: React.ReactNode) => <span className="font-semibold">{chunks}</span>,
             })}
-          </DialogDescription>
-        </DialogHeader>
-        <DialogFooter className="gap-2 sm:gap-0">
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter className="gap-2 sm:gap-0">
           <div className="flex w-full flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-            <Button
-              variant="outline"
+            <AlertDialogCancel
               onClick={() => setIsOpen(false)}
               disabled={isDeleting}
               className="w-full cursor-pointer sm:w-auto">
               {t("deleteDialog.cancel")}
-            </Button>
-            <Button
+            </AlertDialogCancel>
+            <AlertDialogAction
               variant="destructive"
-              onClick={handleDelete}
+              onClick={(event) => {
+                event.preventDefault();
+                void handleDelete();
+              }}
               disabled={isDeleting}
               className="w-full cursor-pointer sm:w-auto">
               {isDeleting ? t("deleteDialog.deleting") : t("deleteDialog.confirm")}
-            </Button>
+            </AlertDialogAction>
           </div>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 }


### PR DESCRIPTION
## Summary
- Replace the seven dedicated destructive dialog flows with shadcn AlertDialog.
- Preserve trigger semantics, async delete behavior, and test ids.

## Verification
- make check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated confirmation dialogs for administrative deletion operations across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->