### PR TITLE
Add dataset metadata file management

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -294,6 +294,7 @@
       "title": "Variable bearbeiten"
     },
     "editor": {
+      "metadata": "Metadateien",
       "projects": "Projekte",
       "splitvariables": "Split-Variablen",
       "title": "Datensatz-Editor für {name}",
@@ -303,6 +304,68 @@
     "error": "Fehler",
     "fetchProjectsError": "Fehler beim Abrufen der Projekte.",
     "name": "Name",
+    "metadata": {
+      "deleteDialog": {
+        "cancel": "Abbrechen",
+        "confirm": "Löschen",
+        "deleting": "Wird gelöscht...",
+        "description": "Möchten Sie die Datei {name} wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.",
+        "error": "Fehler beim Löschen der Metadatendatei.",
+        "title": "Metadatendatei löschen"
+      },
+      "description": "Laden Sie Fragebögen, Variablenbeschreibungen und ergänzende Dokumentation für diesen Datensatz hoch.",
+      "files": {
+        "columns": {
+          "actions": "Aktionen",
+          "name": "Name",
+          "size": "Größe",
+          "type": "Typ",
+          "uploadedAt": "Hochgeladen"
+        },
+        "description": "Alle Metadatendateien, die mit diesem Datensatz verknüpft sind.",
+        "download": "Datei herunterladen",
+        "emptyDescription": "Laden Sie Dokumentation hoch, damit Nutzer diesen Datensatz besser verstehen.",
+        "emptyTitle": "Noch keine Metadateien",
+        "loading": "Metadateien werden geladen...",
+        "title": "Dateien"
+      },
+      "messages": {
+        "deleteError": "Fehler beim Löschen der Metadatendatei.",
+        "deleteSuccess": "Metadatendatei erfolgreich gelöscht.",
+        "fetchError": "Metadateien konnten nicht geladen werden.",
+        "uploadError": "Metadatendatei konnte nicht hochgeladen werden.",
+        "uploadSuccess": "Metadatendatei erfolgreich hochgeladen."
+      },
+      "title": "Metadateien",
+      "types": {
+        "documentation": "Dokumentation",
+        "other": "Sonstiges",
+        "questionnaire": "Fragebogen",
+        "variable_descriptions": "Variablenbeschreibungen"
+      },
+      "upload": {
+        "clickToUpload": "Zum Hochladen klicken",
+        "description": "Akzeptierte Formate: PDF, DOCX, XLSX, PPTX, ODT, ODS, ODP, WEBP, PNG, JPEG. Maximal 10 MB.",
+        "descriptionLabel": "Beschreibung",
+        "fileLabel": "Datei",
+        "nameLabel": "Anzeigename",
+        "orDragAndDrop": "oder per Drag & Drop ablegen",
+        "submit": "Metadatendatei hochladen",
+        "supportedFormats": "Unterstützte Formate: PDF, DOCX, XLSX, PPTX, ODT, ODS, ODP, WEBP, PNG, JPEG (max. 10 MB)",
+        "title": "Hochladen",
+        "typeLabel": "Kategorie",
+        "uploading": "Wird hochgeladen..."
+      },
+      "validation": {
+        "file": {
+          "required": "Bitte wählen Sie genau eine Datei aus",
+          "sizeLimit": "Die Dateigröße muss kleiner als {size} MB sein"
+        },
+        "name": {
+          "required": "Name ist erforderlich"
+        }
+      }
+    },
     "projects": "Projekte",
     "projectsExplanation": "Ein Datensatz kann einem oder mehreren Projekten hinzugefügt werden.",
     "searchPlaceholder": "Variablen durchsuchen",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -294,6 +294,7 @@
       "title": "Edit Variable"
     },
     "editor": {
+      "metadata": "Metadata Files",
       "projects": "Projects",
       "splitvariables": "Split Variables",
       "title": "Dataset Editor for {name}",
@@ -303,6 +304,68 @@
     "error": "Error",
     "fetchProjectsError": "Failed to fetch projects.",
     "name": "Name",
+    "metadata": {
+      "deleteDialog": {
+        "cancel": "Cancel",
+        "confirm": "Delete",
+        "deleting": "Deleting...",
+        "description": "Are you sure you want to delete the file {name}? This action cannot be undone.",
+        "error": "Failed to delete metadata file.",
+        "title": "Delete metadata file"
+      },
+      "description": "Upload questionnaires, variable descriptions, and supporting documentation for this dataset.",
+      "files": {
+        "columns": {
+          "actions": "Actions",
+          "name": "Name",
+          "size": "Size",
+          "type": "Type",
+          "uploadedAt": "Uploaded"
+        },
+        "description": "All metadata files linked to this dataset.",
+        "download": "Download file",
+        "emptyDescription": "Upload documentation to help users understand this dataset.",
+        "emptyTitle": "No metadata files yet",
+        "loading": "Loading metadata files...",
+        "title": "Files"
+      },
+      "messages": {
+        "deleteError": "Failed to delete metadata file.",
+        "deleteSuccess": "Metadata file deleted successfully.",
+        "fetchError": "Failed to load metadata files.",
+        "uploadError": "Failed to upload metadata file.",
+        "uploadSuccess": "Metadata file uploaded successfully."
+      },
+      "title": "Metadata Files",
+      "types": {
+        "documentation": "Documentation",
+        "other": "Other",
+        "questionnaire": "Questionnaire",
+        "variable_descriptions": "Variable descriptions"
+      },
+      "upload": {
+        "clickToUpload": "Click to upload",
+        "description": "Accepted formats: PDF, DOCX, XLSX, PPTX, ODT, ODS, ODP, WEBP, PNG, JPEG. Maximum 10 MB.",
+        "descriptionLabel": "Description",
+        "fileLabel": "File",
+        "nameLabel": "Display Name",
+        "orDragAndDrop": "or drag and drop",
+        "submit": "Upload metadata file",
+        "supportedFormats": "Supported formats: PDF, DOCX, XLSX, PPTX, ODT, ODS, ODP, WEBP, PNG, JPEG (max 10 MB)",
+        "title": "Upload",
+        "typeLabel": "Category",
+        "uploading": "Uploading..."
+      },
+      "validation": {
+        "file": {
+          "required": "Please select exactly one file",
+          "sizeLimit": "File size must be less than {size}MB"
+        },
+        "name": {
+          "required": "Name is required"
+        }
+      }
+    },
     "projects": "Projects",
     "projectsExplanation": "A dataset can be added to one or more projects.",
     "searchPlaceholder": "Search variables",

--- a/apps/web/src/actions/dataset-metadata.ts
+++ b/apps/web/src/actions/dataset-metadata.ts
@@ -1,0 +1,110 @@
+"use server";
+
+import { eq } from "drizzle-orm";
+import { defaultClient as db } from "@repo/database/clients";
+import { dataset as datasetEntity, datasetMetadataFile } from "@repo/database/schema";
+import { findById } from "@/dal/dataset-metadata";
+import { USER_ADMIN_ROLE } from "@/lib/auth";
+import { validateMetadataFile } from "@/lib/document-validation";
+import {
+  ServerActionException,
+  ServerActionNotAuthorizedException,
+  ServerActionValidationException,
+} from "@/lib/exception";
+import { getSessionOrThrow, withDatasetAccess } from "@/lib/server-action-utils";
+import { deleteDatasetMetadataFile, putDatasetMetadataFile } from "@/lib/storage";
+
+type ActionResult = {
+  success: boolean;
+  error?: string;
+};
+
+export const uploadDatasetMetadataFile = withDatasetAccess(
+  async (datasetId: string, formData: FormData): Promise<ActionResult> => {
+    const session = await getSessionOrThrow();
+    const file = formData.get("file");
+    const metadataType = formData.get("metadataType");
+    const name = (formData.get("name") as string | null)?.trim() || null;
+    const description = (formData.get("description") as string | null)?.trim() || null;
+
+    if (!(file instanceof File)) {
+      throw new ServerActionValidationException("No file provided");
+    }
+
+    if (
+      metadataType !== "questionnaire" &&
+      metadataType !== "variable_descriptions" &&
+      metadataType !== "documentation" &&
+      metadataType !== "other"
+    ) {
+      throw new ServerActionValidationException("Invalid metadata type");
+    }
+
+    const validation = await validateMetadataFile(file);
+    if (!validation.success) {
+      return { success: false, error: validation.error };
+    }
+
+    const targetDataset = await db.query.dataset.findFirst({
+      where: eq(datasetEntity.id, datasetId),
+    });
+
+    if (!targetDataset) {
+      throw new ServerActionException("Dataset not found");
+    }
+
+    const { s3Key } = await putDatasetMetadataFile({
+      buffer: validation.buffer,
+      contentType: validation.mimeType,
+      datasetId,
+      extension: validation.extension,
+      originalFilename: file.name,
+      organizationId: targetDataset.organizationId,
+      userId: session.user.id,
+      fileHash: validation.fileHash,
+    });
+
+    try {
+      await db.insert(datasetMetadataFile).values({
+        datasetId,
+        organizationId: targetDataset.organizationId,
+        uploadedBy: session.user.id,
+        name: name || file.name,
+        description,
+        fileType: validation.mimeType,
+        fileSize: file.size,
+        fileHash: validation.fileHash,
+        storageKey: s3Key,
+        metadataType,
+        uploadedAt: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+    } catch (error) {
+      await deleteDatasetMetadataFile(s3Key);
+      throw error;
+    }
+
+    return { success: true };
+  }
+);
+
+export const removeDatasetMetadataFile = withDatasetAccess(
+  async (datasetId: string, fileId: string): Promise<ActionResult> => {
+    const session = await getSessionOrThrow();
+    const file = await findById(fileId);
+
+    if (!file || file.datasetId !== datasetId) {
+      throw new ServerActionValidationException("Metadata file not found");
+    }
+
+    if (session.user.role !== USER_ADMIN_ROLE && file.uploadedBy !== session.user.id) {
+      throw new ServerActionNotAuthorizedException("You can only delete files you uploaded");
+    }
+
+    await deleteDatasetMetadataFile(file.storageKey);
+    await db.delete(datasetMetadataFile).where(eq(datasetMetadataFile.id, fileId));
+
+    return { success: true };
+  }
+);

--- a/apps/web/src/app/(admin)/admin/datasets/[id]/editor/page.tsx
+++ b/apps/web/src/app/(admin)/admin/datasets/[id]/editor/page.tsx
@@ -2,6 +2,7 @@ import { getTranslations } from "next-intl/server";
 import { notFound } from "next/navigation";
 import { DatasetVariablesDataTable } from "@/components/admin/dataset-editor/data-table";
 import { DatasetProjects } from "@/components/admin/dataset-editor/dataset-projects";
+import { MetadataFilesTab } from "@/components/admin/dataset-editor/metadata-files-tab";
 import { SplitVariablesTab } from "@/components/admin/dataset-editor/splitvariables-tab";
 import { VariablesetTab } from "@/components/admin/dataset-editor/variableset-tab";
 import { PageLayout } from "@/components/page/page-layout";
@@ -46,6 +47,9 @@ export default async function Page({ params }: PageProps) {
           <TabsTrigger value="projects" data-testid="app.admin.editor.projects.tab">
             {t("editor.projects")}
           </TabsTrigger>
+          <TabsTrigger value="metadata" data-testid="app.admin.editor.metadata.tab">
+            {t("editor.metadata")}
+          </TabsTrigger>
         </TabsList>
         <TabsContent value="variables">
           <DatasetVariablesDataTable datasetId={id} />
@@ -58,6 +62,9 @@ export default async function Page({ params }: PageProps) {
         </TabsContent>
         <TabsContent value="projects">
           <DatasetProjects datasetId={id} organizationId={organization.id} />
+        </TabsContent>
+        <TabsContent value="metadata">
+          <MetadataFilesTab datasetId={id} />
         </TabsContent>
       </Tabs>
     </PageLayout>

--- a/apps/web/src/app/api/datasets/[id]/metadata-files/[fileId]/route.ts
+++ b/apps/web/src/app/api/datasets/[id]/metadata-files/[fileId]/route.ts
@@ -1,0 +1,66 @@
+import { GetObjectCommand } from "@aws-sdk/client-s3";
+import { NextResponse } from "next/server";
+import { assertAccess } from "@/dal/dataset";
+import { findById } from "@/dal/dataset-metadata";
+import { env } from "@/env";
+import { raiseExceptionResponse } from "@/lib/exception";
+import { getS3Client } from "@/lib/storage";
+
+export const dynamic = "force-dynamic";
+
+const s3Client = getS3Client();
+
+type RouteParams = {
+  params: Promise<{
+    id: string;
+    fileId: string;
+  }>;
+};
+
+export async function GET(request: Request, { params }: RouteParams) {
+  const { id, fileId } = await params;
+
+  if (!id || !fileId) {
+    return NextResponse.json({ error: "ID is required" }, { status: 400 });
+  }
+
+  try {
+    await assertAccess(id);
+
+    const file = await findById(fileId);
+    if (!file || file.datasetId !== id) {
+      return new NextResponse("File not found", { status: 404 });
+    }
+
+    const response = await s3Client.send(
+      new GetObjectCommand({
+        Bucket: env.S3_BUCKET_NAME,
+        Key: file.storageKey,
+        ResponseContentDisposition: `attachment; filename="${file.name}"`,
+      })
+    );
+
+    if (!response.Body) {
+      return new NextResponse("File not found", { status: 404 });
+    }
+
+    const chunks: Uint8Array[] = [];
+    // eslint-disable-next-line
+    for await (const chunk of response.Body as any) {
+      chunks.push(chunk);
+    }
+    const buffer = Buffer.concat(chunks);
+
+    return new NextResponse(buffer, {
+      headers: {
+        "Cache-Control": "private, max-age=0, must-revalidate",
+        "Content-Disposition": `attachment; filename="${file.name}"`,
+        "Content-Length": buffer.length.toString(),
+        "Content-Type": file.fileType || "application/octet-stream",
+      },
+    });
+  } catch (error) {
+    console.error("Error downloading metadata file:", error, request.url);
+    return raiseExceptionResponse(error);
+  }
+}

--- a/apps/web/src/app/api/datasets/[id]/metadata-files/route.ts
+++ b/apps/web/src/app/api/datasets/[id]/metadata-files/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { assertAccess } from "@/dal/dataset";
+import { listByDataset } from "@/dal/dataset-metadata";
+import { raiseExceptionResponse } from "@/lib/exception";
+import { processUrlParams } from "../../../handler";
+
+export const dynamic = "force-dynamic";
+
+type RouteParams = {
+  params: Promise<{
+    id: string;
+  }>;
+};
+
+export async function GET(request: Request, { params }: RouteParams) {
+  const { id } = await params;
+
+  if (!id) {
+    return NextResponse.json({ error: "ID is required" }, { status: 400 });
+  }
+
+  try {
+    await assertAccess(id);
+
+    const { limit, offset, search, orderBy, filters } = processUrlParams(new URL(request.url).searchParams);
+    const result = await listByDataset(id, {
+      filters,
+      limit,
+      offset,
+      orderBy,
+      search,
+      searchColumns: ["name", "description"],
+    });
+
+    return NextResponse.json(result);
+  } catch (error) {
+    return raiseExceptionResponse(error);
+  }
+}

--- a/apps/web/src/components/admin/dataset-editor/metadata-file-delete-dialog.tsx
+++ b/apps/web/src/components/admin/dataset-editor/metadata-file-delete-dialog.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { Trash } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+import { toast } from "sonner";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+
+type MetadataFileDeleteDialogProps = {
+  fileId: string;
+  fileName: string;
+  onDelete: (fileId: string) => Promise<void>;
+};
+
+export function MetadataFileDeleteDialog({ fileId, fileName, onDelete }: MetadataFileDeleteDialogProps) {
+  const t = useTranslations("adminDatasetEditor.metadata.deleteDialog");
+  const [open, setOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleDelete = async () => {
+    try {
+      setIsDeleting(true);
+      await onDelete(fileId);
+      setOpen(false);
+    } catch (error) {
+      console.error(error);
+      toast.error(t("error"));
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger asChild>
+        <Button
+          variant="outline"
+          size="icon"
+          type="button"
+          data-testid={`admin.dataset.metadata-file.delete.${fileId}`}
+          title={t("confirm")}
+          className="cursor-pointer">
+          <Trash className="h-4 w-4" />
+          <span className="sr-only">{t("confirm")}</span>
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent className="sm:max-w-[425px]">
+        <AlertDialogHeader>
+          <AlertDialogTitle>{t("title")}</AlertDialogTitle>
+          <AlertDialogDescription>{t("description", { name: fileName })}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter className="gap-2 sm:gap-0">
+          <div className="flex w-full flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+            <AlertDialogCancel disabled={isDeleting} className="w-full cursor-pointer sm:w-auto">
+              {t("cancel")}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              data-testid={`admin.dataset.metadata-file.delete-confirm.${fileId}`}
+              variant="destructive"
+              disabled={isDeleting}
+              className="w-full cursor-pointer sm:w-auto"
+              onClick={(event) => {
+                event.preventDefault();
+                void handleDelete();
+              }}>
+              {isDeleting ? t("deleting") : t("confirm")}
+            </AlertDialogAction>
+          </div>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/web/src/components/admin/dataset-editor/metadata-file-upload-form.tsx
+++ b/apps/web/src/components/admin/dataset-editor/metadata-file-upload-form.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Loader2, Upload, X } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+import { uploadDatasetMetadataFile } from "@/actions/dataset-metadata";
+import { Button } from "@/components/ui/button";
+import { Field, FieldError, FieldGroup, FieldLabel } from "@/components/ui/field";
+import {
+  FileUpload,
+  FileUploadDropzone,
+  FileUploadItem,
+  FileUploadItemDelete,
+  FileUploadItemMetadata,
+  FileUploadItemPreview,
+  FileUploadList,
+} from "@/components/ui/file-upload";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { MAX_METADATA_FILE_SIZE } from "@/lib/document-validation";
+
+type FormValues = {
+  description: string;
+  file: File[];
+  metadataType: "documentation" | "other" | "questionnaire" | "variable_descriptions";
+  name: string;
+};
+
+type MetadataFileUploadFormProps = {
+  datasetId: string;
+  onUploaded: () => Promise<void> | void;
+};
+
+const acceptedExtensions = ".pdf,.docx,.xlsx,.pptx,.odt,.ods,.odp,.webp,.png,.jpg,.jpeg";
+
+export function MetadataFileUploadForm({ datasetId, onUploaded }: MetadataFileUploadFormProps) {
+  const t = useTranslations("adminDatasetEditor.metadata");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(
+      z.object({
+        description: z.string(),
+        file: z
+          .array(z.custom<File>())
+          .min(1, t("validation.file.required"))
+          .max(1, t("validation.file.required"))
+          .refine((files) => files.every((file) => file.size <= MAX_METADATA_FILE_SIZE), {
+            message: t("validation.file.sizeLimit", { size: 10 }),
+            path: ["file"],
+          }),
+        metadataType: z.enum(["documentation", "other", "questionnaire", "variable_descriptions"]),
+        name: z.string().trim().min(1, t("validation.name.required")),
+      })
+    ),
+    defaultValues: {
+      description: "",
+      file: [],
+      metadataType: "documentation",
+      name: "",
+    },
+  });
+
+  const onSubmit = async (data: FormValues) => {
+    const [selectedFile] = data.file;
+    if (!selectedFile) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const formData = new FormData();
+      formData.append("file", selectedFile);
+      formData.append("metadataType", data.metadataType);
+      formData.append("name", data.name);
+      formData.append("description", data.description);
+
+      const result = await uploadDatasetMetadataFile(datasetId, formData);
+      if (!result.success) {
+        toast.error(result.error || t("messages.uploadError"));
+        return;
+      }
+
+      toast.success(t("messages.uploadSuccess"));
+      form.reset({
+        description: "",
+        file: [],
+        metadataType: "documentation",
+        name: "",
+      });
+      await onUploaded();
+    } catch (error) {
+      console.error(error);
+      toast.error(t("messages.uploadError"));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <CardShell>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <Controller
+          name="file"
+          control={form.control}
+          render={({ field, fieldState }) => (
+            <Field data-invalid={fieldState.invalid}>
+              <FieldLabel>{t("upload.fileLabel")}</FieldLabel>
+              <FieldGroup>
+                <FileUpload
+                  value={field.value}
+                  onValueChange={(value) => {
+                    const nextFile = value[0];
+                    if (nextFile && !form.getValues("name")) {
+                      form.setValue("name", nextFile.name, { shouldValidate: true });
+                    }
+                    field.onChange(value);
+                  }}
+                  accept={acceptedExtensions}
+                  maxFiles={1}
+                  maxSize={MAX_METADATA_FILE_SIZE}
+                  multiple={false}
+                  onFileReject={(_, message) => {
+                    form.setError("file", { message });
+                  }}
+                  data-testid="admin.dataset.metadata-file.upload.input">
+                  <FileUploadDropzone>
+                    <div className="flex flex-col items-center gap-1 text-center">
+                      <div className="flex items-center justify-center rounded-full border p-2.5">
+                        <Upload className="text-muted-foreground size-6" />
+                      </div>
+                      <p className="text-muted-foreground mb-2 text-sm">
+                        <span className="font-semibold">{t("upload.clickToUpload")}</span> {t("upload.orDragAndDrop")}
+                      </p>
+                      <p className="text-muted-foreground text-xs">{t("upload.supportedFormats")}</p>
+                    </div>
+                  </FileUploadDropzone>
+                  <FileUploadList>
+                    {field.value.map((file) => (
+                      <FileUploadItem
+                        key={`${file.name}-${file.size}`}
+                        value={file}
+                        data-testid="admin.dataset.metadata-file.selected-file">
+                        <FileUploadItemPreview />
+                        <FileUploadItemMetadata />
+                        <FileUploadItemDelete asChild>
+                          <Button variant="ghost" size="icon" className="size-7">
+                            <X />
+                          </Button>
+                        </FileUploadItemDelete>
+                      </FileUploadItem>
+                    ))}
+                  </FileUploadList>
+                </FileUpload>
+              </FieldGroup>
+              {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
+            </Field>
+          )}
+        />
+
+        <Controller
+          name="metadataType"
+          control={form.control}
+          render={({ field, fieldState }) => (
+            <Field data-invalid={fieldState.invalid}>
+              <FieldLabel htmlFor={field.name}>{t("upload.typeLabel")}</FieldLabel>
+              <FieldGroup>
+                <Select value={field.value} onValueChange={field.onChange}>
+                  <SelectTrigger id={field.name} data-testid="admin.dataset.metadata-file.type-trigger">
+                    <SelectValue placeholder={t("upload.typeLabel")} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="questionnaire">{t("types.questionnaire")}</SelectItem>
+                    <SelectItem value="variable_descriptions">{t("types.variable_descriptions")}</SelectItem>
+                    <SelectItem value="documentation">{t("types.documentation")}</SelectItem>
+                    <SelectItem value="other">{t("types.other")}</SelectItem>
+                  </SelectContent>
+                </Select>
+              </FieldGroup>
+              {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
+            </Field>
+          )}
+        />
+
+        <Controller
+          name="name"
+          control={form.control}
+          render={({ field, fieldState }) => (
+            <Field data-invalid={fieldState.invalid}>
+              <FieldLabel htmlFor={field.name}>{t("upload.nameLabel")}</FieldLabel>
+              <FieldGroup>
+                <Input {...field} id={field.name} data-testid="admin.dataset.metadata-file.name-input" />
+              </FieldGroup>
+              {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
+            </Field>
+          )}
+        />
+
+        <Controller
+          name="description"
+          control={form.control}
+          render={({ field, fieldState }) => (
+            <Field data-invalid={fieldState.invalid}>
+              <FieldLabel htmlFor={field.name}>{t("upload.descriptionLabel")}</FieldLabel>
+              <FieldGroup>
+                <Textarea {...field} id={field.name} rows={3} />
+              </FieldGroup>
+              {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
+            </Field>
+          )}
+        />
+
+        <Button type="submit" disabled={isSubmitting} data-testid="admin.dataset.metadata-file.upload.submit">
+          {isSubmitting ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              {t("upload.uploading")}
+            </>
+          ) : (
+            t("upload.submit")
+          )}
+        </Button>
+      </form>
+    </CardShell>
+  );
+}
+
+function CardShell({ children }: { children: React.ReactNode }) {
+  return <div className="rounded-md border p-4">{children}</div>;
+}

--- a/apps/web/src/components/admin/dataset-editor/metadata-files-tab.tsx
+++ b/apps/web/src/components/admin/dataset-editor/metadata-files-tab.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { Download, FileText } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { toast } from "sonner";
+import type { DatasetMetadataFile } from "@repo/database/schema";
+import { removeDatasetMetadataFile } from "@/actions/dataset-metadata";
+import { MetadataFileDeleteDialog } from "@/components/admin/dataset-editor/metadata-file-delete-dialog";
+import { MetadataFileUploadForm } from "@/components/admin/dataset-editor/metadata-file-upload-form";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "@/components/ui/empty";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import type { ApiResponsePayload } from "@/hooks/use-api";
+import { useQueryApi } from "@/hooks/use-query-api";
+
+type MetadataFilesTabProps = {
+  datasetId: string;
+};
+
+type MetadataFilesResponse = ApiResponsePayload<DatasetMetadataFile>;
+
+const formatter = new Intl.DateTimeFormat("en", {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+export function MetadataFilesTab({ datasetId }: MetadataFilesTabProps) {
+  const t = useTranslations("adminDatasetEditor.metadata");
+  const { data, isError, isLoading, refetch } = useQueryApi<MetadataFilesResponse>({
+    endpoint: `/api/datasets/${datasetId}/metadata-files`,
+    pagination: { pageIndex: 0, pageSize: 100 },
+    sorting: [],
+    search: "",
+    queryKey: ["dataset-metadata-files", datasetId],
+  });
+
+  const handleDelete = async (fileId: string) => {
+    const result = await removeDatasetMetadataFile(datasetId, fileId);
+    if (!result.success) {
+      throw new Error(result.error || t("messages.deleteError"));
+    }
+
+    toast.success(t("messages.deleteSuccess"));
+    await refetch();
+  };
+
+  const handleUploaded = async () => {
+    await refetch();
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="mt-6 text-base font-medium">{t("title")}</h2>
+        <p className="text-muted-foreground text-sm">{t("description")}</p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,24rem)_minmax(0,1fr)]">
+        <Card className="rounded-md shadow-xs">
+          <CardHeader>
+            <CardTitle>{t("upload.title")}</CardTitle>
+            <CardDescription>{t("upload.description")}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <MetadataFileUploadForm datasetId={datasetId} onUploaded={handleUploaded} />
+          </CardContent>
+        </Card>
+
+        <Card className="rounded-md shadow-xs">
+          <CardHeader>
+            <CardTitle>{t("files.title")}</CardTitle>
+            <CardDescription>{t("files.description")}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {isError ? (
+              <p className="text-destructive text-sm">{t("messages.fetchError")}</p>
+            ) : isLoading ? (
+              <p className="text-muted-foreground text-sm">{t("files.loading")}</p>
+            ) : data && data.rows.length > 0 ? (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>{t("files.columns.name")}</TableHead>
+                    <TableHead>{t("files.columns.type")}</TableHead>
+                    <TableHead>{t("files.columns.size")}</TableHead>
+                    <TableHead>{t("files.columns.uploadedAt")}</TableHead>
+                    <TableHead className="text-right">{t("files.columns.actions")}</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {data.rows.map((file) => (
+                    <TableRow key={file.id} data-testid={`admin.dataset.metadata-file.row.${file.id}`}>
+                      <TableCell>
+                        <div className="space-y-1">
+                          <div className="font-medium">{file.name}</div>
+                          {file.description ? (
+                            <div className="text-muted-foreground text-xs">{file.description}</div>
+                          ) : null}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant="secondary">{t(`types.${file.metadataType}`)}</Badge>
+                      </TableCell>
+                      <TableCell>{formatFileSize(file.fileSize)}</TableCell>
+                      <TableCell>{formatter.format(new Date(file.uploadedAt))}</TableCell>
+                      <TableCell>
+                        <div className="flex justify-end gap-2">
+                          <Button asChild variant="outline" size="icon" type="button">
+                            <a
+                              href={`/api/datasets/${datasetId}/metadata-files/${file.id}`}
+                              download
+                              data-testid={`admin.dataset.metadata-file.download.${file.id}`}>
+                              <Download className="h-4 w-4" />
+                              <span className="sr-only">{t("files.download")}</span>
+                            </a>
+                          </Button>
+                          <MetadataFileDeleteDialog fileId={file.id} fileName={file.name} onDelete={handleDelete} />
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            ) : (
+              <Empty className="border px-6 py-10">
+                <EmptyHeader>
+                  <EmptyMedia variant="icon">
+                    <FileText className="size-5" />
+                  </EmptyMedia>
+                  <EmptyTitle>{t("files.emptyTitle")}</EmptyTitle>
+                  <EmptyDescription>{t("files.emptyDescription")}</EmptyDescription>
+                </EmptyHeader>
+              </Empty>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+function formatFileSize(bytes: number) {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/apps/web/src/dal/dataset-metadata.ts
+++ b/apps/web/src/dal/dataset-metadata.ts
@@ -1,0 +1,24 @@
+import "server-only";
+import { eq } from "drizzle-orm";
+import { defaultClient as db } from "@repo/database/clients";
+import { datasetMetadataFile, selectDatasetMetadataFileSchema } from "@repo/database/schema";
+import { ListOptions, createList, withSessionCheck } from "@/dal/dal";
+
+const baseList = createList(datasetMetadataFile, selectDatasetMetadataFileSchema);
+
+async function listByDatasetFn(datasetId: string, options: ListOptions = {}) {
+  return baseList({
+    ...options,
+    filters: [...(options.filters ?? []), { column: "datasetId", operator: "eq", value: datasetId }],
+    orderBy: options.orderBy?.length ? options.orderBy : [{ column: "createdAt", direction: "desc" }],
+  });
+}
+
+async function findByIdFn(fileId: string) {
+  return db.query.datasetMetadataFile.findFirst({
+    where: eq(datasetMetadataFile.id, fileId),
+  });
+}
+
+export const listByDataset = withSessionCheck(listByDatasetFn);
+export const findById = withSessionCheck(findByIdFn);

--- a/apps/web/src/dal/dataset.ts
+++ b/apps/web/src/dal/dataset.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import { and, eq } from "drizzle-orm";
 import {
+  datasetMetadataFile,
   datasetProject,
   dataset as entity,
   member,
@@ -11,7 +12,10 @@ import {
 import { getAuthenticatedClient, getSessionUser, withAdminCheck, withSessionCheck } from "@/dal/dal";
 import { createListWithJoins } from "@/dal/dal-joins";
 import { DalException, DalNotAuthorizedException } from "@/lib/exception";
-import { deleteDataset as s3DeleteDataset } from "@/lib/storage";
+import {
+  deleteDataset as s3DeleteDataset,
+  deleteDatasetMetadataFile as s3DeleteDatasetMetadataFile,
+} from "@/lib/storage";
 
 const findFn = async (id: string) => {
   const db = await getAuthenticatedClient();
@@ -53,9 +57,18 @@ export const deleteDataset = withAdminCheck(async (datasetId: string) => {
   }
 
   try {
+    const metadataFiles = await db
+      .select()
+      .from(datasetMetadataFile)
+      .where(eq(datasetMetadataFile.datasetId, datasetId));
+
     // Delete the file from S3 if it exists
     if (dataset.storageKey) {
       await s3DeleteDataset(dataset.storageKey);
+    }
+
+    for (const metadataFileEntry of metadataFiles) {
+      await s3DeleteDatasetMetadataFile(metadataFileEntry.storageKey);
     }
 
     // Delete from database
@@ -97,3 +110,5 @@ async function hasAccess(datasetId: string) {
     .where(and(eq(member.userId, user.id), eq(entity.id, datasetId)));
   return rows.length > 0;
 }
+
+export { hasAccess };

--- a/apps/web/src/lib/document-validation.test.ts
+++ b/apps/web/src/lib/document-validation.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { MAX_METADATA_FILE_SIZE, validateMetadataFile } from "./document-validation";
+
+const pngBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/a5kAAAAASUVORK5CYII=";
+
+describe("validateMetadataFile", () => {
+  test("accepts a valid png file", async () => {
+    const file = new File([Buffer.from(pngBase64, "base64")], "evidence.png", {
+      type: "image/png",
+    });
+
+    const result = await validateMetadataFile(file);
+
+    assert.equal(result.success, true);
+    if (!result.success) {
+      return;
+    }
+
+    assert.equal(result.extension, "png");
+    assert.equal(result.mimeType, "image/png");
+    assert.equal(result.buffer.length > 0, true);
+    assert.equal(result.fileHash.length, 64);
+  });
+
+  test("rejects files larger than the size limit", async () => {
+    const file = new File([Buffer.alloc(MAX_METADATA_FILE_SIZE + 1)], "too-large.png", {
+      type: "image/png",
+    });
+
+    const result = await validateMetadataFile(file);
+
+    assert.deepEqual(result, {
+      success: false,
+      error: `File too large. Maximum size: ${MAX_METADATA_FILE_SIZE / 1024 / 1024}MB.`,
+    });
+  });
+
+  test("rejects extension spoofing", async () => {
+    const file = new File([Buffer.from(pngBase64, "base64")], "fake.pdf", {
+      type: "application/pdf",
+    });
+
+    const result = await validateMetadataFile(file);
+
+    assert.deepEqual(result, {
+      success: false,
+      error: "File extension does not match the actual file content.",
+    });
+  });
+});

--- a/apps/web/src/lib/document-validation.ts
+++ b/apps/web/src/lib/document-validation.ts
@@ -1,0 +1,129 @@
+import { fileTypeFromBuffer } from "file-type";
+import { createHash } from "node:crypto";
+
+export const MAX_METADATA_FILE_SIZE = 10 * 1024 * 1024;
+
+const metadataMimeTypes = {
+  docx: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  jpeg: "image/jpeg",
+  jpg: "image/jpeg",
+  odp: "application/vnd.oasis.opendocument.presentation",
+  ods: "application/vnd.oasis.opendocument.spreadsheet",
+  odt: "application/vnd.oasis.opendocument.text",
+  pdf: "application/pdf",
+  png: "image/png",
+  pptx: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  webp: "image/webp",
+  xlsx: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+} as const;
+
+const ALLOWED_METADATA_FILE_EXTENSIONS = Object.keys(metadataMimeTypes) as (keyof typeof metadataMimeTypes)[];
+
+type MetadataFileExtension = (typeof ALLOWED_METADATA_FILE_EXTENSIONS)[number];
+
+type MetadataFileValidationSuccess = {
+  success: true;
+  buffer: Buffer;
+  extension: MetadataFileExtension;
+  fileHash: string;
+  mimeType: (typeof metadataMimeTypes)[MetadataFileExtension];
+};
+
+type MetadataFileValidationFailure = {
+  success: false;
+  error: string;
+};
+
+type MetadataFileValidationResult = MetadataFileValidationSuccess | MetadataFileValidationFailure;
+
+const allowedFileTypeExtensions = new Set<MetadataFileExtension>(["jpeg", "jpg", "pdf", "png", "webp"]);
+
+const zipContainerSignatures: Record<
+  Exclude<MetadataFileExtension, "jpeg" | "jpg" | "pdf" | "png" | "webp">,
+  string[]
+> = {
+  docx: ["word/"],
+  odp: ["mimetypeapplication/vnd.oasis.opendocument.presentation", "content.xml", "META-INF/manifest.xml"],
+  ods: ["mimetypeapplication/vnd.oasis.opendocument.spreadsheet", "content.xml", "META-INF/manifest.xml"],
+  odt: ["mimetypeapplication/vnd.oasis.opendocument.text", "content.xml", "META-INF/manifest.xml"],
+  pptx: ["ppt/"],
+  xlsx: ["xl/"],
+};
+
+function detectZipContainerType(buffer: Buffer): MetadataFileExtension | null {
+  if (buffer.length < 4 || buffer[0] !== 0x50 || buffer[1] !== 0x4b) {
+    return null;
+  }
+
+  const bufferText = buffer.toString("latin1");
+
+  for (const [extension, markers] of Object.entries(zipContainerSignatures) as [
+    Exclude<MetadataFileExtension, "jpeg" | "jpg" | "pdf" | "png" | "webp">,
+    string[],
+  ][]) {
+    if (markers.every((marker) => bufferText.includes(marker))) {
+      return extension;
+    }
+  }
+
+  return null;
+}
+
+function getExtensionFromName(fileName: string): string | null {
+  const extension = fileName.split(".").pop()?.toLowerCase();
+  return extension || null;
+}
+
+export async function validateMetadataFile(file: File): Promise<MetadataFileValidationResult> {
+  if (file.size > MAX_METADATA_FILE_SIZE) {
+    return {
+      success: false,
+      error: `File too large. Maximum size: ${MAX_METADATA_FILE_SIZE / 1024 / 1024}MB.`,
+    };
+  }
+
+  const originalExtension = getExtensionFromName(file.name);
+  if (!originalExtension || !ALLOWED_METADATA_FILE_EXTENSIONS.includes(originalExtension as MetadataFileExtension)) {
+    return {
+      success: false,
+      error: "Invalid file type. Allowed types: PDF, DOCX, XLSX, PPTX, ODT, ODS, ODP, WEBP, PNG, JPEG.",
+    };
+  }
+
+  const buffer = Buffer.from(await file.arrayBuffer());
+  const fileType = await fileTypeFromBuffer(buffer);
+
+  let detectedExtension: MetadataFileExtension | null = null;
+  if (fileType?.ext === "apng") {
+    detectedExtension = "png";
+  } else if (fileType?.ext && allowedFileTypeExtensions.has(fileType.ext as MetadataFileExtension)) {
+    detectedExtension = fileType.ext === "jpeg" ? "jpg" : (fileType.ext as MetadataFileExtension);
+  } else {
+    detectedExtension = detectZipContainerType(buffer);
+  }
+
+  if (!detectedExtension) {
+    return {
+      success: false,
+      error: "Could not detect file type. Please upload a valid document.",
+    };
+  }
+
+  const normalizedOriginalExtension = originalExtension === "jpeg" ? "jpg" : originalExtension;
+  if (normalizedOriginalExtension !== detectedExtension) {
+    return {
+      success: false,
+      error: "File extension does not match the actual file content.",
+    };
+  }
+
+  const fileHash = createHash("sha256").update(buffer).digest("hex");
+
+  return {
+    success: true,
+    buffer,
+    extension: detectedExtension,
+    fileHash,
+    mimeType: metadataMimeTypes[detectedExtension],
+  };
+}

--- a/apps/web/src/lib/server-action-utils.ts
+++ b/apps/web/src/lib/server-action-utils.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { headers } from "next/headers";
+import { hasAccess } from "@/dal/dataset";
 import { USER_ADMIN_ROLE, auth } from "@/lib/auth";
 import { ServerActionNotAuthorizedException } from "@/lib/exception";
 
@@ -41,6 +42,24 @@ export function withAdminAuth<TArgs extends unknown[], TReturn>(fn: (...args: TA
 export function withAuth<TArgs extends unknown[], TReturn>(fn: (...args: TArgs) => Promise<TReturn>) {
   return async (...args: TArgs): Promise<TReturn> => {
     await getSessionOrThrow();
+    return fn(...args);
+  };
+}
+
+export function withDatasetAccess<TArgs extends [datasetId: string, ...unknown[]], TReturn>(
+  fn: (...args: TArgs) => Promise<TReturn>
+) {
+  return async (...args: TArgs): Promise<TReturn> => {
+    const session = await getSessionOrThrow();
+    const [datasetId] = args;
+
+    if (session.user.role !== USER_ADMIN_ROLE) {
+      const canAccess = await hasAccess(datasetId);
+      if (!canAccess) {
+        throw new ServerActionNotAuthorizedException("You do not have access to this dataset");
+      }
+    }
+
     return fn(...args);
   };
 }

--- a/apps/web/src/lib/storage.ts
+++ b/apps/web/src/lib/storage.ts
@@ -64,3 +64,57 @@ export async function deleteDataset(storageKey: string) {
 
   await getS3Client().send(new DeleteObjectCommand(deleteParams));
 }
+
+type PutDatasetMetadataFileParams = {
+  buffer: Buffer;
+  contentType: string;
+  datasetId: string;
+  extension: string;
+  originalFilename: string;
+  organizationId: string;
+  userId: string;
+  fileHash: string;
+};
+
+export async function putDatasetMetadataFile({
+  buffer,
+  contentType,
+  datasetId,
+  extension,
+  originalFilename,
+  organizationId,
+  userId,
+  fileHash,
+}: PutDatasetMetadataFileParams) {
+  const safeExtension = extension.toLowerCase();
+  const fileKey = `${randomUUID()}.${safeExtension}`;
+  const s3Key = `datasets/${datasetId}/metadata/${fileKey}`;
+
+  await getS3Client().send(
+    new PutObjectCommand({
+      Bucket: env.S3_BUCKET_NAME,
+      Key: s3Key,
+      Body: buffer,
+      ContentType: contentType,
+      Metadata: {
+        "original-filename": originalFilename,
+        "uploaded-by": userId,
+        "dataset-id": datasetId,
+        "organization-id": organizationId,
+        "content-type": contentType,
+        "file-hash": fileHash,
+      },
+    })
+  );
+
+  return { s3Key };
+}
+
+export async function deleteDatasetMetadataFile(storageKey: string) {
+  await getS3Client().send(
+    new DeleteObjectCommand({
+      Bucket: env.S3_BUCKET_NAME,
+      Key: storageKey,
+    })
+  );
+}

--- a/packages/database/migrations/0015_pretty_firelord.sql
+++ b/packages/database/migrations/0015_pretty_firelord.sql
@@ -1,0 +1,23 @@
+CREATE TYPE "public"."dataset_metadata_file_type" AS ENUM('questionnaire', 'variable_descriptions', 'documentation', 'other');--> statement-breakpoint
+CREATE TABLE "dataset_metadata_files" (
+	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
+	"dataset_id" uuid NOT NULL,
+	"organization_id" uuid NOT NULL,
+	"uploaded_by" uuid NOT NULL,
+	"name" text NOT NULL,
+	"description" text,
+	"file_type" text NOT NULL,
+	"file_size" bigint NOT NULL,
+	"file_hash" text NOT NULL,
+	"s3_key" text NOT NULL,
+	"metadata_type" "dataset_metadata_file_type" DEFAULT 'other' NOT NULL,
+	"uploaded_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone
+);
+--> statement-breakpoint
+ALTER TABLE "dataset_metadata_files" ADD CONSTRAINT "dataset_metadata_files_dataset_id_datasets_id_fk" FOREIGN KEY ("dataset_id") REFERENCES "public"."datasets"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "dataset_metadata_files" ADD CONSTRAINT "dataset_metadata_files_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "dataset_metadata_files" ADD CONSTRAINT "dataset_metadata_files_uploaded_by_users_id_fk" FOREIGN KEY ("uploaded_by") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "dataset_metadata_files_dataset_id_idx" ON "dataset_metadata_files" USING btree ("dataset_id");--> statement-breakpoint
+CREATE INDEX "dataset_metadata_files_org_id_idx" ON "dataset_metadata_files" USING btree ("organization_id");

--- a/packages/database/migrations/meta/0015_snapshot.json
+++ b/packages/database/migrations/meta/0015_snapshot.json
@@ -1,0 +1,1720 @@
+{
+  "id": "3f3b6170-fb87-4e94-9730-092985119b7e",
+  "prevId": "878fb529-52d4-4b67-8569-0b1489a5f0a7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitations_organization_id_organizations_id_fk": {
+          "name": "invitations_organization_id_organizations_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_inviter_id_users_id_fk": {
+          "name": "invitations_inviter_id_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "members_organization_id_organizations_id_fk": {
+          "name": "members_organization_id_organizations_id_fk",
+          "tableFrom": "members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "members_user_id_users_id_fk": {
+          "name": "members_user_id_users_id_fk",
+          "tableFrom": "members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "members_organization_id_user_id_role_unique": {
+          "name": "members_organization_id_user_id_role_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "user_id",
+            "role"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "organization_slug_check": {
+          "name": "organization_slug_check",
+          "value": "\"organizations\".\"slug\" ~ '^[a-z0-9]([a-z0-9-]*[a-z0-9])?$'"
+        },
+        "organization_slug_reserved": {
+          "name": "organization_slug_reserved",
+          "value": "\"organizations\".\"slug\" NOT IN ('admin', 'api', 'auth', 'landing', 'goodbye', '_next', 'public', 'user')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.rate_limits": {
+      "name": "rate_limits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "emailUniqueIndex": {
+          "name": "emailUniqueIndex",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.datasets": {
+      "name": "datasets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "datasets_organization_id_organizations_id_fk": {
+          "name": "datasets_organization_id_organizations_id_fk",
+          "tableFrom": "datasets",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dataset_metadata_files": {
+      "name": "dataset_metadata_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata_type": {
+          "name": "metadata_type",
+          "type": "dataset_metadata_file_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "dataset_metadata_files_dataset_id_idx": {
+          "name": "dataset_metadata_files_dataset_id_idx",
+          "columns": [
+            {
+              "expression": "dataset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dataset_metadata_files_org_id_idx": {
+          "name": "dataset_metadata_files_org_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dataset_metadata_files_dataset_id_datasets_id_fk": {
+          "name": "dataset_metadata_files_dataset_id_datasets_id_fk",
+          "tableFrom": "dataset_metadata_files",
+          "tableTo": "datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dataset_metadata_files_organization_id_organizations_id_fk": {
+          "name": "dataset_metadata_files_organization_id_organizations_id_fk",
+          "tableFrom": "dataset_metadata_files",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dataset_metadata_files_uploaded_by_users_id_fk": {
+          "name": "dataset_metadata_files_uploaded_by_users_id_fk",
+          "tableFrom": "dataset_metadata_files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dataset_projects": {
+      "name": "dataset_projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "dataset_project_unique_idx": {
+          "name": "dataset_project_unique_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dataset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dataset_projects_project_id_projects_id_fk": {
+          "name": "dataset_projects_project_id_projects_id_fk",
+          "tableFrom": "dataset_projects",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dataset_projects_dataset_id_datasets_id_fk": {
+          "name": "dataset_projects_dataset_id_datasets_id_fk",
+          "tableFrom": "dataset_projects",
+          "tableTo": "datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dataset_splitvariables": {
+      "name": "dataset_splitvariables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variable_id": {
+          "name": "variable_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dataset_splitvariables_unique_idx": {
+          "name": "dataset_splitvariables_unique_idx",
+          "columns": [
+            {
+              "expression": "dataset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variable_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dataset_splitvariables_dataset_id_idx": {
+          "name": "dataset_splitvariables_dataset_id_idx",
+          "columns": [
+            {
+              "expression": "dataset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dataset_splitvariables_dataset_id_datasets_id_fk": {
+          "name": "dataset_splitvariables_dataset_id_datasets_id_fk",
+          "tableFrom": "dataset_splitvariables",
+          "tableTo": "datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dataset_splitvariables_variable_id_dataset_variables_id_fk": {
+          "name": "dataset_splitvariables_variable_id_dataset_variables_id_fk",
+          "tableFrom": "dataset_splitvariables",
+          "tableTo": "dataset_variables",
+          "columnsFrom": [
+            "variable_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dataset_variables": {
+      "name": "dataset_variables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "dataset_variable_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "measure": {
+          "name": "measure",
+          "type": "dataset_variable_measure",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "variable_labels": {
+          "name": "variable_labels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_labels": {
+          "name": "value_labels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "missing_values": {
+          "name": "missing_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "missing_ranges": {
+          "name": "missing_ranges",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "dataset_variable_unique_idx": {
+          "name": "dataset_variable_unique_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dataset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dataset_variables_dataset_id_datasets_id_fk": {
+          "name": "dataset_variables_dataset_id_datasets_id_fk",
+          "tableFrom": "dataset_variables",
+          "tableTo": "datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dataset_variablesets": {
+      "name": "dataset_variablesets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "category": {
+          "name": "category",
+          "type": "dataset_variableset_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "dataset_variableset_name_dataset_idx": {
+          "name": "dataset_variableset_name_dataset_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dataset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dataset_variablesets_dataset_id_idx": {
+          "name": "dataset_variablesets_dataset_id_idx",
+          "columns": [
+            {
+              "expression": "dataset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dataset_variablesets_parent_id_idx": {
+          "name": "dataset_variablesets_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dataset_variablesets_parent_id_dataset_variablesets_id_fk": {
+          "name": "dataset_variablesets_parent_id_dataset_variablesets_id_fk",
+          "tableFrom": "dataset_variablesets",
+          "tableTo": "dataset_variablesets",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dataset_variablesets_dataset_id_datasets_id_fk": {
+          "name": "dataset_variablesets_dataset_id_datasets_id_fk",
+          "tableFrom": "dataset_variablesets",
+          "tableTo": "datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dataset_variableset_contents": {
+      "name": "dataset_variableset_contents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "variableset_id": {
+          "name": "variableset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "dataset_variableset_content_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variable_id": {
+          "name": "variable_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subset_id": {
+          "name": "subset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "dataset_variableset_contents_variable_idx": {
+          "name": "dataset_variableset_contents_variable_idx",
+          "columns": [
+            {
+              "expression": "variableset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variable_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"dataset_variableset_contents\".\"content_type\" = 'variable'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dataset_variableset_contents_subset_idx": {
+          "name": "dataset_variableset_contents_subset_idx",
+          "columns": [
+            {
+              "expression": "variableset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"dataset_variableset_contents\".\"content_type\" = 'subset'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dataset_variableset_contents_set_position_idx": {
+          "name": "dataset_variableset_contents_set_position_idx",
+          "columns": [
+            {
+              "expression": "variableset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dataset_variableset_contents_variableset_id_dataset_variablesets_id_fk": {
+          "name": "dataset_variableset_contents_variableset_id_dataset_variablesets_id_fk",
+          "tableFrom": "dataset_variableset_contents",
+          "tableTo": "dataset_variablesets",
+          "columnsFrom": [
+            "variableset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dataset_variableset_contents_variable_id_dataset_variables_id_fk": {
+          "name": "dataset_variableset_contents_variable_id_dataset_variables_id_fk",
+          "tableFrom": "dataset_variableset_contents",
+          "tableTo": "dataset_variables",
+          "columnsFrom": [
+            "variable_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dataset_variableset_contents_subset_id_dataset_variablesets_id_fk": {
+          "name": "dataset_variableset_contents_subset_id_dataset_variablesets_id_fk",
+          "tableFrom": "dataset_variableset_contents",
+          "tableTo": "dataset_variablesets",
+          "columnsFrom": [
+            "subset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "content_type_variable_check": {
+          "name": "content_type_variable_check",
+          "value": "(\"dataset_variableset_contents\".\"content_type\" != 'variable' OR (\"dataset_variableset_contents\".\"variable_id\" IS NOT NULL AND \"dataset_variableset_contents\".\"subset_id\" IS NULL))"
+        },
+        "content_type_subset_check": {
+          "name": "content_type_subset_check",
+          "value": "(\"dataset_variableset_contents\".\"content_type\" != 'subset' OR (\"dataset_variableset_contents\".\"subset_id\" IS NOT NULL AND \"dataset_variableset_contents\".\"variable_id\" IS NULL))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "projects_organization_id_organizations_id_fk": {
+          "name": "projects_organization_id_organizations_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_slug_unique": {
+          "name": "projects_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "project_slug_check": {
+          "name": "project_slug_check",
+          "value": "\"projects\".\"slug\" ~ '^[a-z0-9]([a-z0-9-]*[a-z0-9])?$'"
+        },
+        "project_slug_reserved": {
+          "name": "project_slug_reserved",
+          "value": "\"projects\".\"slug\" NOT IN ('admin', 'api', 'auth', 'landing', 'public', 'user')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.dataset_metadata_file_type": {
+      "name": "dataset_metadata_file_type",
+      "schema": "public",
+      "values": [
+        "questionnaire",
+        "variable_descriptions",
+        "documentation",
+        "other"
+      ]
+    },
+    "public.dataset_variableset_category": {
+      "name": "dataset_variableset_category",
+      "schema": "public",
+      "values": [
+        "general",
+        "multi_response"
+      ]
+    },
+    "public.dataset_variableset_content_type": {
+      "name": "dataset_variableset_content_type",
+      "schema": "public",
+      "values": [
+        "variable",
+        "subset"
+      ]
+    },
+    "public.dataset_variable_measure": {
+      "name": "dataset_variable_measure",
+      "schema": "public",
+      "values": [
+        "nominal",
+        "ordinal",
+        "scale",
+        "unknown"
+      ]
+    },
+    "public.dataset_variable_type": {
+      "name": "dataset_variable_type",
+      "schema": "public",
+      "values": [
+        "float",
+        "double",
+        "int8",
+        "int16",
+        "int32",
+        "string",
+        "unknown"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1773334701654,
       "tag": "0014_greedy_kylun",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1777997521790,
+      "tag": "0015_pretty_firelord",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema/app.ts
+++ b/packages/database/src/schema/app.ts
@@ -16,7 +16,7 @@ import {
 } from "drizzle-orm/pg-core";
 import { createInsertSchema, createSelectSchema, createUpdateSchema } from "drizzle-zod";
 import { z } from "zod";
-import { organization } from "./auth.js";
+import { organization, user } from "./auth.js";
 
 export const project = pgTable(
   "projects",
@@ -75,6 +75,55 @@ export const updateDatasetSchema = createUpdateSchema(dataset);
 export type CreateDatasetData = z.infer<typeof insertDatasetSchema>;
 export type Dataset = z.infer<typeof selectDatasetSchema>;
 export type UpdateDatasetData = z.infer<typeof updateDatasetSchema>;
+
+export const datasetMetadataFileTypeEnum = pgEnum("dataset_metadata_file_type", [
+  "questionnaire",
+  "variable_descriptions",
+  "documentation",
+  "other",
+] as const);
+
+export type DatasetMetadataFileType = (typeof datasetMetadataFileTypeEnum.enumValues)[number];
+
+export const datasetMetadataFile = pgTable(
+  "dataset_metadata_files",
+  {
+    id: uuid("id")
+      .primaryKey()
+      .default(sql`uuidv7()`),
+    datasetId: uuid("dataset_id")
+      .notNull()
+      .references(() => dataset.id, { onDelete: "cascade" }),
+    organizationId: uuid("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    uploadedBy: uuid("uploaded_by")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    name: text("name").notNull(),
+    description: text("description"),
+    fileType: text("file_type").notNull(),
+    fileSize: bigint("file_size", { mode: "number" }).notNull(),
+    fileHash: text("file_hash").notNull(),
+    storageKey: text("s3_key").notNull(),
+    metadataType: datasetMetadataFileTypeEnum("metadata_type").notNull().default("other"),
+    uploadedAt: timestamp("uploaded_at", { withTimezone: true }).notNull().defaultNow(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }),
+  },
+  (table) => [
+    index("dataset_metadata_files_dataset_id_idx").on(table.datasetId),
+    index("dataset_metadata_files_org_id_idx").on(table.organizationId),
+  ]
+);
+
+export const insertDatasetMetadataFileSchema = createInsertSchema(datasetMetadataFile);
+export const selectDatasetMetadataFileSchema = createSelectSchema(datasetMetadataFile);
+export const updateDatasetMetadataFileSchema = createUpdateSchema(datasetMetadataFile);
+
+export type CreateDatasetMetadataFileData = z.infer<typeof insertDatasetMetadataFileSchema>;
+export type DatasetMetadataFile = z.infer<typeof selectDatasetMetadataFileSchema>;
+export type UpdateDatasetMetadataFileData = z.infer<typeof updateDatasetMetadataFileSchema>;
 
 export const datasetVariableLabelSchema = z.object({
   default: z.string().min(1), // Required, non-empty

--- a/packages/database/src/schema/relations.ts
+++ b/packages/database/src/schema/relations.ts
@@ -1,6 +1,7 @@
 import { relations } from "drizzle-orm";
 import {
   dataset,
+  datasetMetadataFile,
   datasetProject,
   datasetSplitVariable,
   datasetVariable,
@@ -40,6 +41,7 @@ export const organizationRelations = relations(organization, ({ many }) => ({
   invitations: many(invitation),
   projects: many(project),
   datasets: many(dataset),
+  datasetMetadataFiles: many(datasetMetadataFile),
 }));
 
 // Member relations
@@ -81,10 +83,26 @@ export const datasetRelations = relations(dataset, ({ one, many }) => ({
     fields: [dataset.organizationId],
     references: [organization.id],
   }),
+  metadataFiles: many(datasetMetadataFile),
   variables: many(datasetVariable),
   variablesets: many(datasetVariableset),
   datasetProjects: many(datasetProject),
   splitVariables: many(datasetSplitVariable),
+}));
+
+export const datasetMetadataFileRelations = relations(datasetMetadataFile, ({ one }) => ({
+  dataset: one(dataset, {
+    fields: [datasetMetadataFile.datasetId],
+    references: [dataset.id],
+  }),
+  organization: one(organization, {
+    fields: [datasetMetadataFile.organizationId],
+    references: [organization.id],
+  }),
+  uploadedByUser: one(user, {
+    fields: [datasetMetadataFile.uploadedBy],
+    references: [user.id],
+  }),
 }));
 
 // DatasetVariable relations

--- a/packages/e2e-web/tests/admin-datasets.spec.ts
+++ b/packages/e2e-web/tests/admin-datasets.spec.ts
@@ -30,6 +30,43 @@ test.describe("Admin Datasets", () => {
     await page.getByRole("button", { name: "Add to project" }).click();
   });
 
+  test("should upload and delete a metadata file from the dataset editor", async ({ page }) => {
+    const datasetName = `Metadata Dataset ${Date.now().toLocaleString()}`;
+
+    await page.goto("/");
+    await loginUser(page, testUsers.admin.email, testUsers.admin.password);
+    await page.goto("/admin/datasets");
+    await expect(page.getByTestId("admin.datasets.page")).toBeVisible();
+
+    await page.getByTestId("admin.datasets.create.upload").click();
+    const uploadFile = page.getByTestId("file-upload-input").locator('input[type="file"]');
+    await uploadFile.setInputFiles("testdata/spss/demo.sav");
+    await page.getByTestId("app.admin.dataset.selected-file").waitFor({ timeout: 5000 });
+    await page.getByTestId("app.admin.dataset.name-input").fill(datasetName);
+    await page.getByTestId("app.admin.dataset.organization-trigger").click();
+    await page.getByTestId("org-option-test-organization").click();
+    await page.getByTestId("app.admin.dataset.upload-button").click();
+
+    await expect(page.getByTestId("admin.datasets.page")).toBeVisible();
+    await page.getByTestId("app.datatable.search-input").fill(datasetName);
+    await page.getByRole("link", { name: datasetName }).click();
+
+    await page.getByTestId("app.admin.editor.metadata.tab").click();
+    const metadataUpload = page.getByTestId("admin.dataset.metadata-file.upload.input").locator('input[type="file"]');
+    await metadataUpload.setInputFiles("testdata/avatar.png");
+    await page.getByTestId("admin.dataset.metadata-file.selected-file").waitFor({ timeout: 5000 });
+    await page.getByTestId("admin.dataset.metadata-file.name-input").fill("Questionnaire image");
+    await page.getByTestId("admin.dataset.metadata-file.upload.submit").click();
+
+    const row = page.locator('[data-testid^="admin.dataset.metadata-file.row."]').first();
+    await expect(row).toBeVisible();
+    await expect(row).toContainText("Questionnaire image");
+
+    await row.locator('[data-testid^="admin.dataset.metadata-file.delete."]').click();
+    await page.locator('[data-testid^="admin.dataset.metadata-file.delete-confirm."]').click();
+    await expect(page.locator('[data-testid^="admin.dataset.metadata-file.row."]')).toHaveCount(0);
+  });
+
   test("should display organization column in datasets grid", async ({ page }) => {
     await page.goto("/");
     await loginUser(page, testUsers.admin.email, testUsers.admin.password);


### PR DESCRIPTION
## Summary
- Add dataset metadata file upload, download, and delete support in the admin dataset editor.
- Persist metadata files in the database and object storage with validation and cleanup.
- Add coverage for the new metadata file flow.

## Verification
- make check
- pnpm --filter @repo/e2e-web exec playwright test tests/admin-datasets.spec.ts --project=chromium

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metadata file management interface to the dataset editor with support for uploading, downloading, and deleting metadata files
  * Implemented validation for metadata file uploads including size limits and supported file type restrictions
  * Created a dedicated metadata tab within the dataset editor for streamlined metadata file organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->